### PR TITLE
refactor WbUrl and UrlRewriter to drop requirement for having a WbUrl start with /

### DIFF
--- a/pywb/handlers.py
+++ b/pywb/handlers.py
@@ -12,6 +12,8 @@ class BaseHandler:
     def get_wburl_type():
         return WbUrl
 
+    def __call__(self, wbrequest):
+        return wbrequest
 
 #=================================================================
 # Standard WB Handler

--- a/pywb/header_rewriter.py
+++ b/pywb/header_rewriter.py
@@ -128,7 +128,7 @@ if __name__ == "__main__" or utils.enable_doctests():
     import pprint
     import url_rewriter
 
-    urlrewriter = url_rewriter.UrlRewriter('/20131226101010/http://example.com/some/path/index.html', '/web/')
+    urlrewriter = url_rewriter.UrlRewriter('20131226101010/http://example.com/some/path/index.html', '/web/')
 
     headerrewriter = HeaderRewriter()
 

--- a/pywb/html_rewriter.py
+++ b/pywb/html_rewriter.py
@@ -310,7 +310,7 @@ class HTMLRewriter(HTMLParser):
 import utils
 if __name__ == "__main__" or utils.enable_doctests():
 
-    url_rewriter = UrlRewriter('/20131226101010/http://example.com/some/path/index.html', '/web/')
+    url_rewriter = UrlRewriter('20131226101010/http://example.com/some/path/index.html', '/web/')
 
     def parse(data, head_insert = None):
         parser = HTMLRewriter(url_rewriter, head_insert = head_insert)

--- a/pywb/regex_rewriters.py
+++ b/pywb/regex_rewriters.py
@@ -224,7 +224,7 @@ class CSSRewriter(RegexRewriter):
 
 import utils
 if __name__ == "__main__" or utils.enable_doctests():
-    arcrw = UrlRewriter('/20131010im_/http://example.com/', '/web/')
+    arcrw = UrlRewriter('20131010im_/http://example.com/', '/web/')
 
     def test_js(string, extra = []):
         return JSRewriter(arcrw, extra).rewrite(string)

--- a/pywb/url_rewriter.py
+++ b/pywb/url_rewriter.py
@@ -6,46 +6,49 @@ from wburl import WbUrl
 
 class UrlRewriter:
     """
-    >>> test_rewrite('other.html', '/20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
+    >>> test_rewrite('other.html', '20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
     'https://web.archive.org/web/20131010/http://example.com/path/other.html'
 
-    >>> test_rewrite('file.js', '/20131010/http://example.com/path/page.html', 'https://web.archive.org/web/', 'js_')
+    >>> test_rewrite('file.js', '20131010/http://example.com/path/page.html', 'https://web.archive.org/web/', 'js_')
     'https://web.archive.org/web/20131010js_/http://example.com/path/file.js'
 
-    >>> test_rewrite('./other.html', '/20130907*/http://example.com/path/page.html', '/coll/')
+    >>> test_rewrite('/other.html', '20130907*/http://example.com/path/page.html', '/coll/')
+    '/coll/20130907*/http://example.com/other.html'
+
+    >>> test_rewrite('./other.html', '20130907*/http://example.com/path/page.html', '/coll/')
     '/coll/20130907*/http://example.com/path/other.html'
 
-    >>> test_rewrite('../other.html', '/20131112im_/http://example.com/path/page.html', '/coll/')
+    >>> test_rewrite('../other.html', '20131112im_/http://example.com/path/page.html', '/coll/')
     '/coll/20131112im_/http://example.com/other.html'
 
-    >>> test_rewrite('../../other.html', '/*/http://example.com/index.html', 'localhost:8080/')
+    >>> test_rewrite('../../other.html', '*/http://example.com/index.html', 'localhost:8080/')
     'localhost:8080/*/http://example.com/other.html'
 
-    >>> test_rewrite('path/../../other.html', '/*/http://example.com/index.html', 'localhost:8080/')
+    >>> test_rewrite('path/../../other.html', '*/http://example.com/index.html', 'localhost:8080/')
     'localhost:8080/*/http://example.com/other.html'
 
-    >>> test_rewrite('http://some-other-site.com', '/20101226101112/http://example.com/index.html', 'localhost:8080/')
+    >>> test_rewrite('http://some-other-site.com', '20101226101112/http://example.com/index.html', 'localhost:8080/')
     'localhost:8080/20101226101112/http://some-other-site.com'
 
-    >>> test_rewrite('../../other.html', '/2020/http://example.com/index.html', '/')
+    >>> test_rewrite('../../other.html', '2020/http://example.com/index.html', '/')
     '/2020/http://example.com/other.html'
 
-    >>> test_rewrite('../../other.html', '/2020/http://example.com/index.html', '')
-    '/2020/http://example.com/other.html'
+    >>> test_rewrite('../../other.html', '2020/http://example.com/index.html', '')
+    '2020/http://example.com/other.html'
 
-    >>> test_rewrite('', '/20131010010203/http://example.com/file.html', '/web/')
+    >>> test_rewrite('', '20131010010203/http://example.com/file.html', '/web/')
     '/web/20131010010203/http://example.com/file.html'
 
-    >>> test_rewrite('#anchor', '/20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
+    >>> test_rewrite('#anchor', '20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
     '#anchor'
 
-    >>> test_rewrite('mailto:example@example.com', '/20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
+    >>> test_rewrite('mailto:example@example.com', '20131010/http://example.com/path/page.html', 'https://web.archive.org/web/')
     'mailto:example@example.com'
 
-    >>> UrlRewriter('/19960708im_/http://domain.example.com/path.txt', '/abc/').get_abs_url()
+    >>> UrlRewriter('19960708im_/http://domain.example.com/path.txt', '/abc/').get_abs_url()
     '/abc/19960708im_/'
 
-    >>> UrlRewriter('/2013id_/example.com/file/path/blah.html', '/123/').get_timestamp_url('20131024')
+    >>> UrlRewriter('2013id_/example.com/file/path/blah.html', '/123/').get_timestamp_url('20131024')
     '/123/20131024id_/http://example.com/file/path/blah.html'
 
     >>> UrlRewriter.strip_protocol('https://example.com') == UrlRewriter.strip_protocol('http://example.com')
@@ -61,8 +64,8 @@ class UrlRewriter:
         self.prefix = prefix
         self.archivalurl_class = self.wburl.__class__
 
-        if self.prefix.endswith('/'):
-            self.prefix = self.prefix[:-1]
+        #if self.prefix.endswith('/'):
+        #    self.prefix = self.prefix[:-1]
 
     def rewrite(self, url, mod = None):
         # if special protocol, no rewriting at all

--- a/pywb/wbrequestresponse.py
+++ b/pywb/wbrequestresponse.py
@@ -7,24 +7,24 @@ import pprint
 class WbRequest:
     """
     >>> WbRequest.from_uri('/save/_embed/example.com/?a=b')
-    {'wb_url': ('latest_replay', '', '', 'http://_embed/example.com/?a=b', '/http://_embed/example.com/?a=b'), 'coll': 'save', 'wb_prefix': '/save/', 'request_uri': '/save/_embed/example.com/?a=b'}
+    {'wb_url': ('latest_replay', '', '', 'http://_embed/example.com/?a=b', 'http://_embed/example.com/?a=b'), 'coll': 'save', 'wb_prefix': '/save/', 'request_uri': '/save/_embed/example.com/?a=b'}
 
     >>> WbRequest.from_uri('/2345/20101024101112im_/example.com/?b=c')
-    {'wb_url': ('replay', '20101024101112', 'im_', 'http://example.com/?b=c', '/20101024101112im_/http://example.com/?b=c'), 'coll': '2345', 'wb_prefix': '/2345/', 'request_uri': '/2345/20101024101112im_/example.com/?b=c'}
+    {'wb_url': ('replay', '20101024101112', 'im_', 'http://example.com/?b=c', '20101024101112im_/http://example.com/?b=c'), 'coll': '2345', 'wb_prefix': '/2345/', 'request_uri': '/2345/20101024101112im_/example.com/?b=c'}
 
     >>> WbRequest.from_uri('/2010/example.com')
-    {'wb_url': ('latest_replay', '', '', 'http://example.com', '/http://example.com'), 'coll': '2010', 'wb_prefix': '/2010/', 'request_uri': '/2010/example.com'}
+    {'wb_url': ('latest_replay', '', '', 'http://example.com', 'http://example.com'), 'coll': '2010', 'wb_prefix': '/2010/', 'request_uri': '/2010/example.com'}
 
     >>> WbRequest.from_uri('../example.com')
-    {'wb_url': ('latest_replay', '', '', 'http://example.com', '/http://example.com'), 'coll': '', 'wb_prefix': '/', 'request_uri': '../example.com'}
+    {'wb_url': ('latest_replay', '', '', 'http://example.com', 'http://example.com'), 'coll': '', 'wb_prefix': '/', 'request_uri': '../example.com'}
 
     # Abs path
     >>> WbRequest.from_uri('/2010/example.com', {'wsgi.url_scheme': 'https', 'HTTP_HOST': 'localhost:8080'}, use_abs_prefix = True)
-    {'wb_url': ('latest_replay', '', '', 'http://example.com', '/http://example.com'), 'coll': '2010', 'wb_prefix': 'https://localhost:8080/2010/', 'request_uri': '/2010/example.com'}
+    {'wb_url': ('latest_replay', '', '', 'http://example.com', 'http://example.com'), 'coll': '2010', 'wb_prefix': 'https://localhost:8080/2010/', 'request_uri': '/2010/example.com'}
 
     # No Scheme, so stick to relative
     >>> WbRequest.from_uri('/2010/example.com', {'HTTP_HOST': 'localhost:8080'}, use_abs_prefix = True)
-    {'wb_url': ('latest_replay', '', '', 'http://example.com', '/http://example.com'), 'coll': '2010', 'wb_prefix': '/2010/', 'request_uri': '/2010/example.com'}
+    {'wb_url': ('latest_replay', '', '', 'http://example.com', 'http://example.com'), 'coll': '2010', 'wb_prefix': '/2010/', 'request_uri': '/2010/example.com'}
 
     """
 
@@ -38,19 +38,19 @@ class WbRequest:
         # Has coll prefix
         if len(parts) == 3:
             wb_prefix = '/' + parts[1] + '/'
-            wb_url = '/' + parts[2]
+            wb_url_str = parts[2]
             coll = parts[1]
         # No Coll Prefix
         elif len(parts) == 2:
             wb_prefix = '/'
-            wb_url = '/' + parts[1]
+            wb_url_str = parts[1]
             coll = ''
         else:
             wb_prefix = '/'
-            wb_url = parts[0]
+            wb_url_str = parts[0]
             coll = ''
 
-        return WbRequest(env, request_uri, wb_prefix, wb_url, coll, use_abs_prefix)
+        return WbRequest(env, request_uri, wb_prefix, wb_url_str, coll, use_abs_prefix)
 
 
     @staticmethod
@@ -61,7 +61,7 @@ class WbRequest:
             return rel_prefix
 
 
-    def __init__(self, env, request_uri, wb_prefix, wb_url, coll, use_abs_prefix = False, wburl_class = WbUrl):
+    def __init__(self, env, request_uri, wb_prefix, wb_url_str, coll, use_abs_prefix = False, wburl_class = WbUrl):
         self.env = env
 
         self.request_uri = request_uri if request_uri else env.get('REL_REQUEST_URI')
@@ -69,9 +69,9 @@ class WbRequest:
         self.wb_prefix = wb_prefix if not use_abs_prefix else WbRequest.make_abs_prefix(env, wb_prefix)
 
         # wb_url present and not root page
-        if wb_url != '/' and wb_url != '' and wburl_class:
-            self.wb_url_str = wb_url
-            self.wb_url = wburl_class(wb_url)
+        if wb_url_str != '/' and wb_url_str != '' and wburl_class:
+            self.wb_url_str = wb_url_str
+            self.wb_url = wburl_class(wb_url_str)
         else:
         # no wb_url, just store blank
             self.wb_url_str = '/'


### PR DESCRIPTION
Changes WbUrl forms:
/2013/im_/example.com -> 2013/im_/example.com
/*/example.com -> */example.com
/example.com -> example.com
- also simplify scheme-agnostic url (//) handling by just eating up extra
  slashes
- add additional doctests on route, with and w/o custom SCRIPT_NAME
