### PR TITLE
Correct error message in run-gunicorn.sh

### DIFF
--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -2,7 +2,7 @@
 pip install gunicorn
 
 if [ $? -ne 0 ]; then
-    "uwsgi install failed"
+    "gunicorn install failed"
     exit 1
 fi
 


### PR DESCRIPTION
This script should refer to "gunicorn" rather than "uwsgI".
