### PR TITLE
wb-manager cli, fix for no arguments

### DIFF
--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -333,6 +333,7 @@ Create manage file based web archive collections
                             formatter_class=RawTextHelpFormatter)
 
     subparsers = parser.add_subparsers(dest='type')
+    subparsers.required = True
 
     # Init Coll
     def do_init(r):


### PR DESCRIPTION
should fix the error when calling the cli with no argument https://bugs.python.org/issue16308 

```
~ wb-manager
Error: 'Namespace' object has no attribute 'func'
```

