### PR TITLE
warcserver/cdx query: filter improvements

### DIFF
--- a/pywb/utils/format.py
+++ b/pywb/utils/format.py
@@ -1,8 +1,8 @@
-from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote, parse_qsl
 import string
 
 
-#=============================================================================
+# ============================================================================
 class ParamFormatter(string.Formatter):
     def __init__(self, params, name='', prefix='param.'):
         self.params = params
@@ -33,7 +33,7 @@ class ParamFormatter(string.Formatter):
         return value
 
 
-#=============================================================================
+# =============================================================================
 def res_template(template, params, **extra_params):
     formatter = params.get('_formatter')
     if not formatter:
@@ -47,5 +47,39 @@ def res_template(template, params, **extra_params):
     res = formatter.format(template, url=url, **extra_params)
 
     return res
+
+
+# =============================================================================
+def to_bool(val):
+    if not val:
+        return False
+
+    if isinstance(val, str):
+        return val.lower() not in ('0', 'false', 'f', 'off')
+    else:
+        return bool(val)
+
+
+# =============================================================================
+def query_to_dict(query_str, multi=None):
+    pairlist = parse_qsl(query_str)
+    if not multi:
+        return dict(pairlist)
+
+    obj = {}
+    for n, v in pairlist:
+        if n not in multi:
+            obj[n] = v
+            continue
+
+        # make_list
+        if n not in obj:
+            obj[n] = v
+        elif isinstance(obj[n], list):
+            obj[n].append(v)
+        else:
+            obj[n] = [obj[n], v]
+
+    return obj
 
 

--- a/pywb/warcserver/basewarcserver.py
+++ b/pywb/warcserver/basewarcserver.py
@@ -1,4 +1,5 @@
 from pywb.warcserver.inputrequest import DirectWSGIInputRequest, POSTInputRequest
+from pywb.utils.format import query_to_dict
 
 from werkzeug.routing import Map, Rule
 from werkzeug.exceptions import HTTPException
@@ -7,7 +8,6 @@ import requests
 import traceback
 import json
 
-from six.moves.urllib.parse import parse_qsl
 import six
 
 JSON_CT = 'application/json; charset=utf-8'
@@ -60,7 +60,7 @@ class BaseWarcServer(object):
     def get_query_dict(self, environ):
         query_str = environ.get('QUERY_STRING')
         if query_str:
-            return dict(parse_qsl(query_str))
+            return query_to_dict(query_str, multi=['filter'])
         else:
             return {}
 

--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -1,5 +1,7 @@
 from warcio.utils import to_native_str
+
 from pywb.utils.loaders import load_yaml_config
+from pywb.utils.format import to_bool
 from pywb import DEFAULT_RULES_FILE
 
 import re
@@ -65,7 +67,7 @@ class FuzzyMatcher(object):
 
         return FuzzyRule(url_prefix, regex, replace_after, filter_str, match_type, find_all)
 
-    def get_fuzzy_match(self, urlkey, params):
+    def get_fuzzy_match(self, urlkey, url, params):
         filters = set()
         matched_rule = None
 
@@ -92,8 +94,6 @@ class FuzzyMatcher(object):
 
         if not matched_rule:
             return None
-
-        url = params['url']
 
         # support matching w/o query if no additional filters
         # don't include trailing '?' if no filters and replace_after '?'
@@ -161,10 +161,14 @@ class FuzzyMatcher(object):
         if found:
             return
 
+        # if fuzzy matching disabled
+        if not to_bool(params.get('allowFuzzy', True)):
+            return
+
         url = params['url']
         urlkey = to_native_str(params['key'], 'utf-8')
 
-        res = self.get_fuzzy_match(urlkey, params)
+        res = self.get_fuzzy_match(urlkey, url, params)
         if not res:
             return
 

--- a/pywb/warcserver/index/query.py
+++ b/pywb/warcserver/index/query.py
@@ -1,6 +1,7 @@
 from six.moves.urllib.parse import urlencode
 from pywb.warcserver.index.cdxobject import CDXException
 from pywb.utils.canonicalize import calc_search_range
+from pywb.utils.format import to_bool
 
 
 #=================================================================
@@ -128,17 +129,9 @@ class CDXQuery(object):
     def page_count(self):
         return self._get_bool('showNumPages')
 
-    def _get_bool(self, name, def_val=False):
+    def _get_bool(self, name):
         v = self.params.get(name)
-        if v:
-            try:
-                v = int(v)
-            except ValueError as ex:
-                v = (v.lower() == 'true')
-        else:
-            v = def_val
-
-        return bool(v)
+        return to_bool(v)
 
     def urlencode(self):
         return urlencode(self.params, True)

--- a/pywb/warcserver/index/test/test_fuzzymatcher.py
+++ b/pywb/warcserver/index/test/test_fuzzymatcher.py
@@ -133,6 +133,14 @@ class TestFuzzy(object):
 
         assert list(cdx_iter) == self.get_expected(url=actual_url, filters=filters)
 
+    def test_no_fuzzy_disabled(self):
+        url = 'http://example.com/?_=123'
+        actual_url = 'http://example.com/'
+        params = self.get_params(url, actual_url)
+        params['allowFuzzy'] = 0
+        cdx_iter, errs = self.fuzzy(self.source, params)
+        assert list(cdx_iter) == []
+
     def test_no_fuzzy_custom_rule_video_id_diff(self):
         url = 'http://youtube.com/get_video_info?a=b&html=true&___abc=123&video_id=ABCD&id=1234'
         actual_url = 'http://youtube.com/get_video_info?a=d&html=true&___abc=125&video_id=ABCE&id=1234'


### PR DESCRIPTION
- pywb.utils.format: add query_to_dict() to convert query string with support for list for certain params
- support multiple values for 'filter' cdx server param (fixes #284)
- pywb.utils.format: add to_bool() to convert string/int to bool (eg. for query args)
- fuzzymatch: add 'allowFuzzy' (default to true) to allow disabling fuzzy matcher
- tests: fuzzymather: test disabling fuzzy matcher with allowFuzzy=0
- tests: cdx-server api: add multiple filter tests, with and without fuzzy matching