### PR TITLE
HEAD requests: fix pywb recording & replay of HEAD requests (force pa…

### DIFF
--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -389,8 +389,12 @@ class LiveWebLoader(BaseLoader):
 
         warc_headers['Content-Type'] = 'application/http; msgtype=response'
 
+        if method == 'HEAD':
+            content_len = 0
+        else:
+            content_len = upstream_res.headers.get('Content-Length', -1)
 
-        self._set_content_len(upstream_res.headers.get('Content-Length', -1),
+        self._set_content_len(content_len,
                               warc_headers,
                               len(http_headers_buff))
 

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -29,6 +29,11 @@ class TestLiveRewriter(BaseConfigTest):
         assert '"http://httpbin.org/anything/abc##xyz"' in resp.text
         assert resp.status_int == 200
 
+    def test_live_head(self, fmod_sl):
+        resp = self.head('/live/{0}httpbin.org/anything/foo', fmod_sl)
+        #assert '"http://httpbin.org/anything/foo"' in resp.text
+        assert resp.status_int == 200
+
     def test_live_live_frame(self):
         resp = self.testapp.get('/live/http://example.com/')
         assert resp.status_int == 200

--- a/tests/test_socks.py
+++ b/tests/test_socks.py
@@ -12,7 +12,7 @@ class TestSOCKSProxy(BaseConfigTest):
     @classmethod
     def setup_class(cls):
         os.environ['SOCKS_HOST'] = 'localhost'
-        os.environ['SOCKS_PORT'] = '8080'
+        os.environ['SOCKS_PORT'] = '0'
 
         pywb_http.patch_socks()
         import pywb.warcserver.resource.responseloader
@@ -25,8 +25,8 @@ class TestSOCKSProxy(BaseConfigTest):
         super(TestSOCKSProxy, cls).teardown_class()
 
     def test_socks_proxy_set(self):
-        assert pywb_http.SOCKS_PROXIES == {'http': 'socks5h://localhost:8080',
-                                           'https': 'socks5h://localhost:8080'
+        assert pywb_http.SOCKS_PROXIES == {'http': 'socks5h://localhost:0',
+                                           'https': 'socks5h://localhost:0'
                                           }
 
     def test_socks_attempt_connect(self, fmod_sl):


### PR DESCRIPTION
…yload of 0 instead of content-length if HEAD request from live web)

tests: fix socks-proxy test to fast-fail to a random unused port to detect proxy hook is enabled