### PR TITLE
Set REQUEST_URI via gevent handler

### DIFF
--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.3'
+__version__ = '2.0.4'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 

--- a/pywb/apps/cli.py
+++ b/pywb/apps/cli.py
@@ -81,9 +81,13 @@ class BaseCli(object):
         return self
 
     def run_gevent(self):
-        from gevent.pywsgi import WSGIServer
+        from pywb.utils.geventserver import GeventServer, RequestURIWSGIHandler
         logging.info('Starting Gevent Server on ' + str(self.r.port))
-        WSGIServer((self.r.bind, self.r.port), self.application).serve_forever()
+        ge = GeventServer(self.application,
+                          port=self.r.port,
+                          hostname=self.r.bind,
+                          handler_class=RequestURIWSGIHandler,
+                          direct=True)
 
 
 #=============================================================================

--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -257,10 +257,16 @@ class FrontEndApp(object):
 
         self.setup_paths(environ, coll, record)
 
-        wb_url_str = to_native_str(url)
+        request_uri = environ.get('REQUEST_URI')
+        script_name = environ.get('SCRIPT_NAME', '') + '/'
+        if request_uri and request_uri.startswith(script_name):
+            wb_url_str = request_uri[len(script_name):]
 
-        if environ.get('QUERY_STRING'):
-            wb_url_str += '?' + environ.get('QUERY_STRING')
+        else:
+            wb_url_str = to_native_str(url)
+
+            if environ.get('QUERY_STRING'):
+                wb_url_str += '?' + environ.get('QUERY_STRING')
 
         metadata = self.get_metadata(coll)
         if record:

--- a/pywb/utils/geventserver.py
+++ b/pywb/utils/geventserver.py
@@ -1,13 +1,14 @@
-from gevent.wsgi import WSGIServer
+from gevent.wsgi import WSGIServer, WSGIHandler
 from gevent import spawn
 import logging
 
 
 # ============================================================================
 class GeventServer(object):
-    def __init__(self, app, port=0, hostname='localhost', handler_class=None):
+    def __init__(self, app, port=0, hostname='localhost', handler_class=None,
+                direct=False):
         self.port = port
-        self.make_server(app, port, hostname, handler_class)
+        self.make_server(app, port, hostname, handler_class, direct=direct)
 
     def stop(self):
         if self.server:
@@ -22,15 +23,25 @@ class GeventServer(object):
             logging.debug('server failed to start on ' + str(port))
             traceback.print_exc()
 
-    def make_server(self, app, port, hostname, handler_class):
+    def make_server(self, app, port, hostname, handler_class, direct=False):
         server = WSGIServer((hostname, port), app, handler_class=handler_class)
         server.init_socket()
         self.port = server.address[1]
 
         self.server = server
-        self.ge = spawn(self._run, server, self.port)
+        if direct:
+            self.ge = None
+            self._run(server, self.port)
+        else:
+            self.ge = spawn(self._run, server, self.port)
 
     def join(self):
         self.ge.join()
 
 
+# ============================================================================
+class RequestURIWSGIHandler(WSGIHandler):
+    def get_environ(self):
+        environ = super(RequestURIWSGIHandler, self).get_environ()
+        environ['REQUEST_URI'] = self.path
+        return environ


### PR DESCRIPTION
When running with default gevent wsgi handler, match the uwsgi behavior and set the `REQUEST_URI` to the unencoded path.
When constructing WbUrl, use the original url passed in to ensure same url is passed to index source.