### PR TITLE
Local httpbin tests + LiveIndexSource improvement

### DIFF
--- a/pywb/recorder/test/test_recorder.py
+++ b/pywb/recorder/test/test_recorder.py
@@ -2,7 +2,7 @@ from gevent import monkey; monkey.patch_all()
 import gevent
 
 from pywb.warcserver.test.testutils import TempDirTests, LiveServerTests, BaseTestClass, to_path
-from pywb.warcserver.test.testutils import FakeRedisTests
+from pywb.warcserver.test.testutils import FakeRedisTests, HttpBinLiveTests
 
 import os
 import webtest
@@ -45,7 +45,7 @@ Cookie: boo=far\r\n\
 
 
 
-class TestRecorder(LiveServerTests, FakeRedisTests, TempDirTests, BaseTestClass):
+class TestRecorder(LiveServerTests, HttpBinLiveTests, FakeRedisTests, TempDirTests, BaseTestClass):
     @classmethod
     def setup_class(cls):
         super(TestRecorder, cls).setup_class()

--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -196,8 +196,7 @@ class RemoteIndexSource(BaseIndexSource):
 
 #=============================================================================
 class LiveIndexSource(BaseIndexSource):
-    def __init__(self, proxy_url='{url}'):
-        self.proxy_url = proxy_url
+    def __init__(self):
         self._init_sesh(DefaultAdapters.live_adapter)
 
     def load_index(self, params):
@@ -216,7 +215,7 @@ class LiveIndexSource(BaseIndexSource):
 
         if params.get('filter') and not mime:
             try:
-                res = self.sesh.head(cdx['url'])
+                res = self.sesh.head(cdx['load_url'])
                 if res.status_code != 405:
                     cdx['status'] = str(res.status_code)
 
@@ -232,7 +231,7 @@ class LiveIndexSource(BaseIndexSource):
         return iter([cdx])
 
     def get_load_url(self, params):
-        return res_template(self.proxy_url, params)
+        return params['url']
 
     def __repr__(self):
         return '{0}()'.format(self.__class__.__name__)

--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -209,7 +209,7 @@ class LiveIndexSource(BaseIndexSource):
         cdx['urlkey'] = params.get('key').decode('utf-8')
         cdx['timestamp'] = timestamp_now()
         cdx['url'] = params['url']
-        cdx['load_url'] = res_template(self.proxy_url, params)
+        cdx['load_url'] = self.get_load_url(params)
         cdx['is_live'] = 'true'
 
         mime = params.get('content_type', '')
@@ -230,6 +230,9 @@ class LiveIndexSource(BaseIndexSource):
         cdx['mime'] = mime
 
         return iter([cdx])
+
+    def get_load_url(self, params):
+        return res_template(self.proxy_url, params)
 
     def __repr__(self):
         return '{0}()'.format(self.__class__.__name__)

--- a/pywb/warcserver/test/test_upstream.py
+++ b/pywb/warcserver/test/test_upstream.py
@@ -14,10 +14,10 @@ from pywb.warcserver.index.aggregator import SimpleAggregator
 
 from pywb.warcserver.upstreamindexsource import UpstreamMementoIndexSource, UpstreamAggIndexSource
 
-from .testutils import LiveServerTests, BaseTestClass
+from .testutils import LiveServerTests, HttpBinLiveTests, BaseTestClass
 
 
-class TestUpstream(LiveServerTests, BaseTestClass):
+class TestUpstream(LiveServerTests, HttpBinLiveTests, BaseTestClass):
     def setup(self):
         app = BaseWarcServer()
 

--- a/pywb/warcserver/test/testutils.py
+++ b/pywb/warcserver/test/testutils.py
@@ -15,7 +15,6 @@ from pywb.warcserver.index.aggregator import SimpleAggregator
 from pywb.warcserver.index.indexsource import LiveIndexSource, MementoIndexSource
 
 from pywb.utils.geventserver import GeventServer
-from pywb.utils.format import res_template
 
 from pywb import get_test_dir
 from pywb.utils.wbexception import NotFoundException
@@ -176,7 +175,7 @@ class HttpBinLiveTests(object):
         def get_load_url(self, params):
             params['url'] = params['url'].replace('http://httpbin.org/', httpbin_local)
             params['url'] = params['url'].replace('https://httpbin.org/', httpbin_local)
-            return res_template(self.proxy_url, params)
+            return params['url']
 
         cls.indexmock = patch('pywb.warcserver.index.indexsource.LiveIndexSource.get_load_url', get_load_url)
         cls.indexmock.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ warcio>=1.5.0
 chardet
 requests
 redis
-jinja2<2.9
+jinja2
 surt>=0.3.0
 brotlipy
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         'mock',
         'urllib3',
         'werkzeug',
-        'httpbin',
+        'httpbin==0.5.0',
        ],
     cmdclass={'test': PyTest},
     test_suite='',

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         'mock',
         'urllib3',
         'werkzeug',
+        'httpbin',
        ],
     cmdclass={'test': PyTest},
     test_suite='',

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -27,13 +27,14 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
         assert resp.status_int == 200
 
     def test_live_anchor_encode(self, fmod_sl):
-        resp = self.get('/live/{0}httpbin.org/anything/abc%23%23xyz', fmod_sl)
-        assert '"http://httpbin.org/anything/abc##xyz"' in resp.text
+        resp = self.get('/live/{0}httpbin.org/get?val=abc%23%23xyz', fmod_sl)
+        assert 'get?val=abc%23%23xyz"' in resp.text
+        assert '"val": "abc##xyz"' in resp.text
+        #assert '"http://httpbin.org/anything/abc##xyz"' in resp.text
         assert resp.status_int == 200
 
     def test_live_head(self, fmod_sl):
-        resp = self.head('/live/{0}httpbin.org/anything/foo', fmod_sl)
-        #assert '"http://httpbin.org/anything/foo"' in resp.text
+        resp = self.head('/live/{0}httpbin.org/get?foo=bar', fmod_sl)
         assert resp.status_int == 200
 
     def test_live_live_frame(self):

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -1,9 +1,10 @@
 from .base_config_test import BaseConfigTest, fmod_sl
+from pywb.warcserver.test.testutils import HttpBinLiveTests
 import pytest
 
 
 # ============================================================================
-class TestLiveRewriter(BaseConfigTest):
+class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
     @classmethod
     def setup_class(cls):
         super(TestLiveRewriter, cls).setup_class('config_test.yaml')

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,4 @@
-from pywb.warcserver.test.testutils import BaseTestClass, TempDirTests
+from pywb.warcserver.test.testutils import BaseTestClass, TempDirTests, HttpBinLiveTests
 
 from .base_config_test import CollsDirMixin
 from pywb.utils.geventserver import GeventServer, RequestURIWSGIHandler
@@ -99,7 +99,7 @@ class TestProxy(BaseTestProxy):
 
 
 # ============================================================================
-class TestRecordingProxy(CollsDirMixin, BaseTestProxy):
+class TestRecordingProxy(HttpBinLiveTests, CollsDirMixin, BaseTestProxy):
     @classmethod
     def setup_class(cls, coll='pywb', config_file='config_test.yaml'):
         super(TestRecordingProxy, cls).setup_class('test', 'config_test_record.yaml', recording=True)

--- a/tests/test_record_replay.py
+++ b/tests/test_record_replay.py
@@ -1,7 +1,7 @@
 from .base_config_test import BaseConfigTest, fmod, CollsDirMixin
 from pywb.manager.manager import main as manager
 from pywb.manager.autoindex import AutoIndexer
-from pywb.warcserver.test.testutils import to_path
+from pywb.warcserver.test.testutils import to_path, HttpBinLiveTests
 
 import os
 import time
@@ -9,7 +9,7 @@ import json
 
 
 # ============================================================================
-class TestRecordReplay(CollsDirMixin, BaseConfigTest):
+class TestRecordReplay(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
     @classmethod
     def setup_class(cls):
         super(TestRecordReplay, cls).setup_class('config_test_record.yaml')
@@ -133,7 +133,7 @@ class TestRecordReplay(CollsDirMixin, BaseConfigTest):
 
 
 # ============================================================================
-class TestRecordCustomConfig(CollsDirMixin, BaseConfigTest):
+class TestRecordCustomConfig(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
     @classmethod
     def setup_class(cls):
         rec_custom = {'recorder': {'source_coll': 'live',


### PR DESCRIPTION
Update tests to use a local `httpbin` instance instead of httpbin.org, which may be down.
Make LiveIndexSource more extensible by making get_load_url() overridable