### PR TITLE
Improve indexing for amf requests

### DIFF
--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -2,6 +2,5 @@ certauth
 youtube-dl
 boto3
 uwsgi
-git+https://github.com/t0m/pyamf.git@python3
 git+https://github.com/esnme/ultrajson.git
 pysocks

--- a/pywb/rewrite/rewrite_amf.py
+++ b/pywb/rewrite/rewrite_amf.py
@@ -43,6 +43,8 @@ class RewriteAMF(BufferedRewriter):  #pragma: no cover
             import traceback
             traceback.print_exc()
             print(e)
+
+            stream.seek(0)
             return stream
 
 

--- a/pywb/warcserver/amf.py
+++ b/pywb/warcserver/amf.py
@@ -51,7 +51,7 @@ class Amf:
             return ""
 
         elif isinstance(request_object, object) and hasattr(request_object, "__dict__"):
-            classname = type(request_object).__name__
+            classname = request_object.__class__.__name__
             properties = request_object.__dict__
             bodies = dict()
             for prop in properties:

--- a/pywb/warcserver/amf.py
+++ b/pywb/warcserver/amf.py
@@ -1,0 +1,64 @@
+import json
+import six
+from pyamf.remoting import Envelope, Request
+from pyamf.flex.messaging import RemotingMessage
+
+
+class Amf:
+
+    @staticmethod
+    def get_representation(request_object, max_calls=500):
+
+        max_calls = max_calls - 1
+
+        if max_calls < 0:
+            raise Exception("Amf.get_representation maximum number of calls reached")
+
+        if isinstance(request_object, Envelope):
+            # Remove order of Request
+            bodies = []
+            for i in request_object.bodies:
+                bodies.append(Amf.get_representation(i[1], max_calls))
+            bodies = sorted(bodies)
+
+            return "<Envelope>{bodies}</Envelope>".format(bodies="[" + ",".join(bodies) + "]")
+
+        elif isinstance(request_object, Request):
+            # Remove cyclic reference
+            target = request_object.target
+            body = Amf.get_representation(request_object.body, max_calls)
+            return "<Request target={target}>{body}</Request>".format(**locals())
+
+        elif isinstance(request_object, RemotingMessage):
+            # Remove random properties
+            operation = request_object.operation
+            body = Amf.get_representation(request_object.body, max_calls)
+            return "<RemotingMessage operation={operation}>{body}</RemotingMessage>".format(**locals())
+
+        elif isinstance(request_object, dict):
+            return json.dumps(request_object, sort_keys=True)
+
+        elif isinstance(request_object, list):
+            bodies = []
+            for i in request_object:
+                bodies.append(Amf.get_representation(i, max_calls))
+            return "[" + ",".join(bodies) + "]"
+
+        elif isinstance(request_object, six.string_types):
+            return request_object
+
+        elif request_object is None:
+            return ""
+
+        elif isinstance(request_object, object) and hasattr(request_object, "__dict__"):
+            classname = type(request_object).__name__
+            properties = request_object.__dict__
+            bodies = dict()
+            for prop in properties:
+                bodies[prop] = Amf.get_representation(getattr(request_object, prop), max_calls)
+            bodies = Amf.get_representation(bodies, max_calls)
+
+            return '<{classname}>{bodies}</{classname}>'.format(**locals())
+
+        else:
+            return repr(request_object)

--- a/pywb/warcserver/test/test_amf.py
+++ b/pywb/warcserver/test/test_amf.py
@@ -9,8 +9,7 @@ from pyamf.flex.messaging import RemotingMessage
 
 
 class CustomObject:
-    def __init__(self, secret):
-        self.secret = secret
+    secret = None
 
 
 pyamf.register_class(CustomObject, "custom.object")
@@ -34,7 +33,8 @@ def generate_flex_request(message_body=None):
 class TestAmf(object):
 
     def test_can_parse_custom_object(self):
-        a = CustomObject("a")
+        a = CustomObject()
+        a.secret = "a"
 
         encoded = generate_amf_request(request_body=[a])
         decoded = decode(BytesIO(encoded))
@@ -69,7 +69,7 @@ class TestAmf(object):
         assert Amf.get_representation(a) != Amf.get_representation(b)
 
     def test_limit_recursive_calls(self):
-        a = CustomObject("a")
+        a = CustomObject()
         a.secret = a
 
         encoded = generate_amf_request(request_body=[a])

--- a/pywb/warcserver/test/test_amf.py
+++ b/pywb/warcserver/test/test_amf.py
@@ -1,0 +1,81 @@
+from pywb.warcserver.amf import Amf
+
+import pyamf
+import uuid
+
+from io import BytesIO
+from pyamf.remoting import Envelope, Request, encode, decode
+from pyamf.flex.messaging import RemotingMessage
+
+
+class CustomObject:
+    def __init__(self, secret):
+        self.secret = secret
+
+
+pyamf.register_class(CustomObject, "custom.object")
+
+
+def generate_amf_request(request_body=None):
+    req = Request(target='UserService', body=request_body)
+    ev = Envelope(pyamf.AMF3)
+    ev['/0'] = req
+
+    return encode(ev).getvalue()
+
+
+def generate_flex_request(message_body=None):
+    msg = RemotingMessage(operation='retrieveUser',
+                          messageId=str(uuid.uuid4()).upper(),
+                          body=message_body)
+    return generate_amf_request([msg])
+
+
+class TestAmf(object):
+
+    def test_can_parse_custom_object(self):
+        a = CustomObject("a")
+
+        encoded = generate_amf_request(request_body=[a])
+        decoded = decode(BytesIO(encoded))
+
+        assert Amf.get_representation(decoded) == \
+               '<Envelope>[<Request target=UserService>[<CustomObject>{"secret": "a"}</CustomObject>]</Request>]</Envelope>'
+
+    def test_parse_amf_request_with_envelope(self):
+        encoded = generate_amf_request([{"the": "body"}])
+        decoded = decode(BytesIO(encoded))
+        assert Amf.get_representation(decoded) == \
+               '<Envelope>[<Request target=UserService>[{"the": "body"}]</Request>]</Envelope>'
+
+    def test_parse_flex_request_with_envelope(self):
+        encoded = generate_flex_request([{"the": "body"}])
+        decoded = decode(BytesIO(encoded))
+        assert Amf.get_representation(decoded) == \
+               '<Envelope>[<Request target=UserService>[<RemotingMessage operation=retrieveUser>[{"the": "body"}]</RemotingMessage>]</Request>]</Envelope>'
+
+    def test_position_in_dict_ignored(self):
+        a = Request(target=None, body={"a": 1, "b": 2})
+        b = Request(target=None, body={"b": 2, "a": 1})
+        c = Request(target=None, body={"a": 2, "b": 1})
+
+        assert Amf.get_representation(a) == Amf.get_representation(b)
+        assert Amf.get_representation(a) != Amf.get_representation(c)
+
+    def test_order_of_array_preserved(self):
+        a = Request(target=None, body=[1, 2])
+        b = Request(target=None, body=[2, 1])
+
+        assert Amf.get_representation(a) != Amf.get_representation(b)
+
+    def test_limit_recursive_calls(self):
+        a = CustomObject("a")
+        a.secret = a
+
+        encoded = generate_amf_request(request_body=[a])
+        decoded = decode(BytesIO(encoded))
+        try:
+            Amf.get_representation(decoded)
+            assert False, "should not be called"
+        except Exception as e:
+            assert "maximum number of calls reached" in str(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ gevent==1.2.2
 webassets==0.12.1
 portalocker
 wsgiprox>=1.4.1
-Py3AMF
+git+https://github.com/t0m/pyamf.git@python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ gevent==1.2.2
 webassets==0.12.1
 portalocker
 wsgiprox>=1.4.1
+Py3AMF


### PR DESCRIPTION
The current version of pywb have some problems with AMF:
- It was developed to only support AMF messages from Adobe Flex (Adobe Flex is a Flash framework)
- The body of a request can be JSON, and the order of attribute can be a problem.
 
Here, we have developed a small class that gives a string representation of an Amf request. It supports pure AMF and Flex messages and tries to reorder the attributes of JSON objects.

Here are some pure AMF websites:

1.  [**matribu**](http://matribu.onf.ca/#/matribu)  -  [replay link](https://webrecorder.io/hhardy/amf/20180420140548$br:chrome:53/http://matribu.onf.ca/#/matribu) : With the patch, you will be able to record and replay the project.   
2.  **PIB** -  [replay link](https://webrecorder.io/hhardy/amf/http://pib.onf.ca/)To see movies, you need RTMP server (not HTTP), but, at least, you should be able to browse the website with the patch.

Unfortunately, I do not have any Flex projects to test support of it. (only the unit test) If you have one, I will be glad to test it and give you the feedback. 

Humbert.


