### PR TITLE
serviceworker postMessage rewrite fix

### DIFF
--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -160,6 +160,10 @@ class JSWombatProxyRewriterMixin(object):
     local_init_func = '\nvar {0} = function(name) {{\
 return (self._wb_wombat && self._wb_wombat.local_init &&\
  self._wb_wombat.local_init(name)) || self[name]; }};\n\
+if (!self.__WB_pmw && typeof self.Client !== "undefined") {{ \n\
+  self.Client.prototype.__WB_pmw = function(obj) {{ return this; }}; \n\
+  self.MessagePort.prototype.__WB_pmw = function(obj) {{ return this; }}; \n\
+}}\n\
 if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
 {{\n'
 


### PR DESCRIPTION
This PR is to fix #322 by patching the prototypes of [Client](https://w3c.github.io/ServiceWorker/#client-interface) and [MessagePort](https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports) interfaces if the client interface is not undefined.

To understand how this works consider the following IDLs:

```webidl
[Exposed=ServiceWorker]
interface Client {
  readonly attribute USVString url;
  readonly attribute DOMString id;
  readonly attribute ClientType type;
  void postMessage(any message, optional sequence<object> transfer = []);
};
```
The client interface is only exposed on the execution environments global object for service workers.
We can use this information to guard the override of ```Client.postMessage```.
```js
if (!self.__WB_pmw && typeof self.Client !== "undefined") 
```
The patch override applied to ```Client.postMessage```  by this PR
```js
self.Client.prototype.__WB_pmw = function(obj) { return this; }
```
differs from the current convention for handling non existing ```__WB_pmw``` properties
```js
self.__WB_pmw = function(obj) { return obj; }
```
because the message needs to be sent directly to the controlled client.

By returning ```this``` rather than the ```obj``` param of the function, we ensure that the rewritten ```postMessage``` call
```js
client.__WB_pmw(self).postMessage(message);
```
uses the client interface not the service worker.

Likewise, the patch override of ```MessagePort.postMessage``` follows the same reasoning.
```js
// patch override
self.MessagePort.prototype.__WB_pmw = function(obj) { return this; };

// rewritten
event.ports[0].__WB_pmw(self).postMessage(event.data.m + " SW Says 'Hello back!'");
```
In the context of a service worker the message port is found on an [```ExtendableMessageEvent ```](https://w3c.github.io/ServiceWorker/#extendablemessageevent-interface), a  [```ServiceWorkerMessageEvent```](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerMessageEvent).
```webidl
[Constructor(DOMString type, optional ExtendableMessageEventInit eventInitDict), Exposed=ServiceWorker]
interface ExtendableMessageEvent : ExtendableEvent {
  readonly attribute any data;
  readonly attribute USVString origin;
  readonly attribute DOMString lastEventId;
  [SameObject] readonly attribute (Client or ServiceWorker or MessagePort)? source;
  readonly attribute FrozenArray<MessagePort> ports;
};

[Exposed=(Window,Worker,AudioWorklet), Transferable]
interface MessagePort : EventTarget {
  void postMessage(any message, optional sequence<object> transfer = []);
  void start();
  void close();

  // event handlers
  attribute EventHandler onmessage;
  attribute EventHandler onmessageerror;
};
```


