### PR TITLE
Fix wombats overrides of document.[write, writeln] to account for the variadic case

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2647,7 +2647,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             var argLen = arguments.length;
             var string;
             if (argLen === 0) {
-                return orig_doc_write.call(this);
+                return orig_doc_writeln.call(this);
             } else if (argLen === 1) {
                 string = arguments[0];
             } else {

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -92,6 +92,9 @@ var _WBWombat = function($wbwindow, wbinfo) {
     var message_listeners = new FuncMap();
     var storage_listeners = new FuncMap();
 
+    // to avoid incurring the cost of our override
+    var origFunctionApply = $wbwindow.Function.prototype.apply;
+
     //============================================
     function is_host_url(str) {
         // Good guess that's its a hostname
@@ -2607,18 +2610,29 @@ var _WBWombat = function($wbwindow, wbinfo) {
             return;
         }
 
+        // both document.[write,writeln] are variadic functions
+        // we must concatenate the arguments when length > 1
+
         // Write
         var orig_doc_write = $wbwindow.document.write;
 
-        var new_write = function(string) {
-            new_buff = rewrite_html(string, true);
+        var new_write = function() {
+            var string;
+            if (arguments.length <= 1) {
+                string = arguments[0];
+            } else {
+                // using Array.apply for optimization reasons
+                var argArray = origFunctionApply.call($wbwindow.Array, arguments);
+                string = argArray.join('');
+            }
+            var new_buff = rewrite_html(string, true);
             if (!new_buff) {
                 return;
             }
             var res = orig_doc_write.call(this, new_buff);
             init_new_window_wombat(this.defaultView);
             return res;
-        }
+        };
 
         $wbwindow.document.write = new_write;
         $wbwindow.Document.prototype.write = new_write;
@@ -2626,15 +2640,22 @@ var _WBWombat = function($wbwindow, wbinfo) {
         // Writeln
         var orig_doc_writeln = $wbwindow.document.writeln;
 
-        var new_writeln = function(string) {
-            new_buff = rewrite_html(string, true);
+        var new_writeln = function() {
+            var string;
+            if (arguments.length <= 1) {
+                string = arguments[0];
+            } else {
+                var argArray = origFunctionApply.call($wbwindow.Array, arguments);
+                string = argArray.join('');
+            }
+            var new_buff = rewrite_html(string, true);
             if (!new_buff) {
                 return;
             }
             var res = orig_doc_writeln.call(this, new_buff);
             init_new_window_wombat(this.defaultView);
             return res;
-        }
+        };
 
         $wbwindow.document.writeln = new_writeln;
         $wbwindow.Document.prototype.writeln = new_writeln;
@@ -2646,7 +2667,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             var res = orig_doc_open.call(this);
             init_new_window_wombat(this.defaultView);
             return res;
-        }
+        };
 
         $wbwindow.document.open = new_open;
         $wbwindow.Document.prototype.open = new_open;

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2617,8 +2617,11 @@ var _WBWombat = function($wbwindow, wbinfo) {
         var orig_doc_write = $wbwindow.document.write;
 
         var new_write = function() {
+            var argLen = arguments.length;
             var string;
-            if (arguments.length <= 1) {
+            if (argLen === 0) {
+                return orig_doc_write.call(this);
+            } else if (argLen === 1) {
                 string = arguments[0];
             } else {
                 // using Array.apply for optimization reasons
@@ -2641,8 +2644,11 @@ var _WBWombat = function($wbwindow, wbinfo) {
         var orig_doc_writeln = $wbwindow.document.writeln;
 
         var new_writeln = function() {
+            var argLen = arguments.length;
             var string;
-            if (arguments.length <= 1) {
+            if (argLen === 0) {
+                return orig_doc_write.call(this);
+            } else if (argLen === 1) {
                 string = arguments[0];
             } else {
                 var argArray = origFunctionApply.call($wbwindow.Array, arguments);


### PR DESCRIPTION
This PR fixes #324 by check for the variadic case in the document.[write, writeln] function overrides.   

For reference consider the [Document IDL](https://html.spec.whatwg.org/multipage/dom.html#the-document-object)  excerpt below
```webidl
[OverrideBuiltins]
partial interface Document {
  [CEReactions] void write(DOMString... text);
  [CEReactions] void writeln(DOMString... text);
}
```
The changes made by this PR can be summarized as:
1. Added a reference to `$wbwindow.Function.prototype.apply` called `origFunctionApply` to account for the Function.apply override
2. Made the argument string (from the original override) a function variable 
3. If the length of the `arguments` object is less than or equal to 1, set string to `arguments[0]`
4. Otherwise convert the `arguments` object to an array via `origFunctionApply.call($wbwindow.Array, arguments);` and set string variable to the results of `argArray.join('')` 
