### PR TITLE
default_banner fix: save last state for use with 'title' event change…

### DIFF
--- a/pywb/static/default_banner.js
+++ b/pywb/static/default_banner.js
@@ -88,6 +88,8 @@ This file is part of pywb, https://github.com/webrecorder/pywb
         return;
     }
 
+    var last_state = {};
+
     window.addEventListener("load", function() {
         if (window.wbinfo) {
             init("_wb_plain_banner");
@@ -107,8 +109,10 @@ This file is part of pywb, https://github.com/webrecorder/pywb
 
                 if (type == "load" || type == "replace-url") {
                     state = event.data;
+                    last_state = state;
                     title = event.data.title || title;
                 } else if (type == "title") {
+                    state = last_state;
                     title = event.data.title;
                 } else {
                     return;


### PR DESCRIPTION
…s -- use previous url, timestamp when changing title

(Fix issue with default banner when only title is updated, as no url state change is sent, resulting in error)