### PR TITLE
postMessage edge cases fixes: safer postmessage:

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2206,9 +2206,11 @@ var _WBWombat = function($wbwindow, wbinfo) {
             }
 
             var to_origin = targetOrigin;
-            
-            if (starts_with(to_origin, obj.location.origin)) {
-                to_origin = "*";
+
+            // if passed in origin is the replay (rewriting missed somewhere?)
+            // set origin to current 'from' origin
+            if (to_origin == obj.location.origin) {
+                to_origin = from;
             }
 
             var new_message = {"from": from,
@@ -2218,7 +2220,14 @@ var _WBWombat = function($wbwindow, wbinfo) {
                                "from_top": from_top,
                               }
 
+            // set to 'real' origin if not '*'
             if (targetOrigin != "*") {
+                // if target origin is null (about:blank) or empty, don't pass event at all
+                // as it would never succeed
+                if (obj.location.origin == "null" || obj.location.origin == "") {
+                    return;
+                }
+                // set to actual (rewritten) origin
                 targetOrigin = obj.location.origin;
             }
 


### PR DESCRIPTION
- if targetOrigin is the replay host, default to unrewritten from origin, not '*'
- don't set targetOrigin to 'null' or empty to avoid errors
- if target window's unrewritten origin is actually 'null' or '', don't pass message at all, and don't set to '*' -- represents actual behavior,
as postMessage to 'null' origin (about:blank page) will be received only if targetOrigin is already '*'.

Fixes some subtle behavior related to postMessage override when calling postMessage on an about:blank window. Avoid setting targetOrigin to `*` or to `"null"` or `""` empty origin. Don't send message at all if ending up empty or null origin.