### PR TITLE
origin header improvement: if Referer header is available, compute Or…

### DIFF
--- a/pywb/rewrite/rewriteinputreq.py
+++ b/pywb/rewrite/rewriteinputreq.py
@@ -49,8 +49,14 @@ class RewriteInputRequest(DirectWSGIInputRequest):
 
             elif name == 'HTTP_ORIGIN':
                 name = 'Origin'
-                if self.splits:
-                    value = (self.splits.scheme + '://' + self.splits.netloc)
+                referrer = self.env.get('HTTP_REFERER')
+                if referrer:
+                    splits = urlsplit(referrer)
+                else:
+                    splits = self.splits
+
+                if splits:
+                    value = (splits.scheme + '://' + splits.netloc)
 
             elif name == 'HTTP_X_CSRFTOKEN':
                 name = 'X-CSRFToken'

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -64,3 +64,22 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
     def test_deflate(self, fmod_sl):
         resp = self.get('/live/{0}http://httpbin.org/deflate', fmod_sl)
         assert b'"deflated": true' in resp.body
+
+    def test_live_origin_and_referrer(self, fmod_sl):
+        headers = {'Referer': 'http://localhost:80/live/{0}http://example.com/test'.format(fmod_sl),
+                   'Origin': 'http://localhost:80'
+                  }
+
+        resp = self.get('/live/{0}http://httpbin.org/get?test=headers', fmod_sl, headers=headers)
+
+        assert resp.json['headers']['Referer'] == 'http://example.com/test'
+        assert resp.json['headers']['Origin'] == 'http://example.com'
+
+    def test_live_origin_no_referrer(self, fmod_sl):
+        headers = {'Origin': 'http://localhost:80'}
+
+        resp = self.get('/live/{0}http://httpbin.org/get?test=headers', fmod_sl, headers=headers)
+
+        assert resp.json['headers']['Origin'] == 'http://httpbin.org'
+
+


### PR DESCRIPTION
…igin from the Referer, not from target url

(Origin header received will be the pywb host, using Referer will result in more accurate Origin, which may not be the target url)
tests: add tests to verify Origin header with and without Referer

Better computation of `Origin` header