### PR TITLE
mod fix for cookies: set wbinfo.mod to replay_mod (mp_ or '') to avoi…

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -348,6 +348,7 @@ class RewriterApp(object):
                                                        top_url,
                                                        environ,
                                                        framed_replay,
+                                                       replay_mod=self.replay_mod,
                                                        config=self.config))
 
         cookie_rewriter = None

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -18,7 +18,7 @@
   wbinfo.timestamp = "{{ cdx.timestamp }}";
   wbinfo.request_ts = "{{ wb_url.timestamp }}";
   wbinfo.prefix = decodeURI("{{ wb_prefix }}");
-  wbinfo.mod = "{{ wb_url.mod }}";
+  wbinfo.mod = "{{ replay_mod }}";
   wbinfo.is_framed = {{ is_framed }};
   wbinfo.is_live = {{ is_live }};
   wbinfo.coll = "{{ coll }}";


### PR DESCRIPTION
…d cookie issues caused by content loaded with wrong modifier (eg. with yt comments)

When using the modifier of the current page, occasionally end up with incorrect modifiers for html pages (eg. cs_). This can cause issues with cookies especially. To avoid this, always set the `wbinfo.mod` to the default replay modifier (mp_ or blank if not framed).
See #326 for possible causes of wrong modifier and other rewriting issues. However, this should at least fix the wrong modifier issue.