### PR TITLE
rewrite fixes (avoid infinite loops):

### DIFF
--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -195,6 +195,7 @@ if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
            (r'(?<=[\n])\s*this\b(?=(?:\.(?:{0})\b))'.format(prop_str), self.replace_str(';' + self.THIS_RW), 0),
            (r'(?<![$.])\s*this\b(?=(?:\.(?:{0})\b))'.format(prop_str), self.replace_str(self.THIS_RW), 0),
            (r'(?<=[=])\s*this\b\s*(?![.$])', self.replace_str(self.THIS_RW), 0),
+           ('\}(?:\s*\))?\s*\(this\)', self.replace_str(self.THIS_RW), 0),
            (r'(?<=[^|&][|&]{2})\s*this\b\s*(?![|&.$]([^|&]|$))', self.replace_str(self.THIS_RW), 0),
         ]
 

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -160,6 +160,12 @@ r"""
 >>> _test_js_obj_proxy('if (that != this) { ... }')
 'if (that != (this && this._WB_wombat_obj_proxy || this)) { ... }'
 
+>>> _test_js_obj_proxy('function(){...} (this)')
+'function(){...} ((this && this._WB_wombat_obj_proxy || this))'
+
+>>> _test_js_obj_proxy('function(){...} )   (this); foo(this)')
+'function(){...} )   ((this && this._WB_wombat_obj_proxy || this)); foo(this)'
+
 >>> _test_js_obj_proxy('var foo = that || this  ;')
 'var foo = that || (this && this._WB_wombat_obj_proxy || this)  ;'
 

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -58,7 +58,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
         this.map = function(param) {
             for (var i = 0; i < this._arr.length; i++) {
-                (this._arr[i][0])(param);
+                (this._arr[i][1])(param);
             }
         }
     }
@@ -2369,7 +2369,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         override_on_prop("onmessage", WrappedListener);
-        override_on_prop("onstroage", SameOriginListener);
+        override_on_prop("onstorage", SameOriginListener);
     }
 
 


### PR DESCRIPTION
- server-side: rewrite '}(this)' or '})(this)' with js object proxy override convert
- client-side: fix typo in 'onstorage' override, fix typo that prevented SameOriginListener() from being used -- ensure
custom 'onstorage' events only sent to original window