### PR TITLE
Wombat rewrite improvements and updated server-side rewriting of link rel='preload'

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -73,12 +73,20 @@ class HTMLRewriterMixin(StreamingRewriter):
 
     DATA_RW_PROTOCOLS = ('http://', 'https://', '//')
 
-    PRELOAD_TYPES = {'script': 'js_',
-                     'style': 'cs_',
-                     'image': 'im_',
-                     'document': 'if_',
-                     'fetch': 'mp_'
-                    }
+    PRELOAD_TYPES = {
+        'script': 'js_',
+        'worker': 'js_',
+        'style': 'cs_',
+        'image': 'im_',
+        'document': 'if_',
+        'fetch': 'mp_',
+        'font': 'oe_',
+        'audio': 'oe_',
+        'video': 'oe_',
+        'embed': 'oe_',
+        'object': 'oe_',
+        'track': 'oe_',
+    }
 
     #===========================
     class AccumBuff:


### PR DESCRIPTION
### Updated server-side rewriting of  &lt;link rel='preload' as='x'&gt;
The `PRELOAD_TYPES` dictionary in `html_rewriter.py` was updated to include the `as` values: 
- `js_`: worker
- `oe_`: font, audio, video, embed, object, and track

This was done to in-order to ensure rewriting of all values listed in the [W3C Preload Spec](https://w3c.github.io/preload/).
Browser support [not behind flag](https://caniuse.com/#search=preload): Edge >= 17, Firefox >= 59, Chrome >= 50, Safari >= 11.1, Opera >= 37, and modern mobile browsers 

### Added client-side rewriting of &lt;link rel='preload' as='x'&gt; and &lt;link rel='import' [as='x]'&gt;
In order to support dynamic addition of `link` tags with `rel='preload'`, the `PRELOAD_TYPES` dictionary in `html_rewriter.py` was added to wombat as `linkAsTypes` object.
The `linkAsTypes` object in wombat also supports the rewriting of dynamic addition of `link` tags with `rel='import'` that contain the `as='x'` attribute. 
Browser support [not behind flag](https://caniuse.com/#feat=imports) for `link rel='import'` is Chrome >= 36, Opera >= 23, and modern Android Chromium and Opera browsers.
Firefox >= 32 has support for this feature but it is behind a flag. 

The `override_attr` function in wombat was updated to include logic to select the correct rewrite modifier for `link href` rewrites based on `rel=[import|preload]` and `as='x'`.
Remaining support in wombat was added via the next change. 
This fixes #326 
 
### Added helper method for determining the correct rewrite modifier to be used in client-side rewriting and updated duplicate modifier logic in wombat
The function `rwModForElement` was added to wombat in order to both simplify rewrite modifier selection and support  `link href` rewriting when `rel=[import|preload]` .
`rwModForElement` takes two arguments: `elem` (the element with a attribute being rewritten) and `attrName` (the attribute to be rewritten) , returning the appropriate modifier based on the element attribute combination.
Supporting the function is the object `tagToMod` that contains a "complete" list of tags currently being rewritten to their attribute modfiers.
The `tagToMod` object is keyed to the elements `tagName` which returns the an object keyed to the rewritten attributes of the tag. 
If an element and or tag combination is not included in the `tagToMod` object undefined is returned which is equivalent to the preexisting logic.
 
### Added Element.insertAdjacentElement override
The `insertAdjacentElement` function found on the `Element` interface is a companion function to `insertAdjacentHTML` .
It behaves similarly to `insertAdjacentHTML` except that the last argument is an `Element` not a `DOMString` .
The rewriting logic is as follows:
- If the Element is not operating under the  `_no_rewrite` flag, rewrite the element using the `rewrite_elem` function 
- Then check to see if the  element has children then if so use the  `recurse_rewrite_elem` function 
The reasoning for the addition rewriting via `recurse_rewrite_elem` will be explained in the next change.
  
### Added special case rewriting of nested elements in Element.insertAdjacentElement  and Node.[appendChild|replaceChild|insertBefore]
In addition to adding the additional rewriting via  `recurse_rewrite_elem` in the `Element.insertAdjacentElement`, this PR adds the same checks to the overrides of `Node.[appendChild|replaceChild|insertBefore]`.
The reason why this is necessary will become apparent when considering the following seemingly "contrived" example and the rewrite behavior before this PR.
 ```js
const existingDoc  = new DOMParser().parseFromString(document.documentElement.outerHTML, 'text/html')
document.documentElement.appendChild(existingDoc.body)
```
As you are aware wombat does not apply an override to the `DOMParser` interface due to its usage internally and retrieving the `innerHTML` and `outerHTML` of any Element returns **raw unwritten HTML**. 
Also as you are aware the behavior of the `appendChild` override before this PR was to only use `rewrite_elem` function when the element to be rewritten `nodeType` is `Node.ELEMENT_NODE`.
The `rewrite_elem` function is not recursive and `document.body.nodeType  === Node.ELEMENT_NODE`.
And... additions to the `document` in this manner always result in resource fetches by the browser.
Hence the reason for this change.
   
### Add MouseEvent override to account for the view argument which is window
MouseEvents can be created one of two ways
```js
// way one
const event = new MouseEvent("click", { view: window });
// way two
const evt = document.createEvent("MouseEvents"); 
evt.initMouseEvent("click", true, true, window, 0, 0, 0, 80, 20, false, false, false, false, 0, null);
```
In both cases the `view` init argument is an instance of `window` which is a wombat proxy and native DOM methods / constructors do not take kindly to JS Proxies when they are expecting instances of window.
This affects replay and recording of map integrations and 3d applications using canvases hence the override. 
The override for the first way is done similarly like the Audio override with the addition of a checking if the view init property is not null and if it is not null we deproxy it.
Additionally the `override_prop_to_proxy` for `view` is applied to the `MouseEvent` prototype.
The override  `initMouseEvent` checks to see if view is not null and if it is not null, it is deproxied.

### Updated wb_unrewrite_rx to now consider protocol and host as optional to fix imgur
The unrewrite regex was updated from `"(" + wb_origin + ")?" + wb_rel_prefix + "[^/]+/"` to `"((" + wb_proto + ")?\/\/" + wb_host + ")?" + wb_rel_prefix + "[^/]+/"`.
This was done to account for when the rewritten URL is `//localhost:8080/live///a.b.com and the following use case.
```js
elementB.innerHTML = elementA.innerHTML;
```
 
### Fixed implicit variable declaration that resulted in global pollution and possible variable collisions in rewriting logic
This change was to address the usage of implicit variable declarations in wombat which leads to global pollution, variable collisions resulting from the implicit declaration and performance degradation.
When a variable is not declared with `var`, `let`, or `const`, it becomes implicitly added to the global execution object which in web browsers is `window`. 
The resulting runtime resolution time for this is costly. 
Please see [The Horror of Implicit Globals](http://blog.niftysnippets.org/2008/03/horror-of-implicit-globals.html), and [bluebird optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers) for more information.
   
### Nit document.[write|writeln] override: rather than using Array.apply then Array.join we now use just Array.join as it works on array like objects
As the title for this changes states this is a nit and an optimization change resulting from my admittedly unfamiliarity with working with the arguments object.
[`Array.prototype.join` works on array-like objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join#Joining_an_array-like_object), thus we do not have to convert the arguments object to an array using `Array.apply` then call `join` on the newly created array.  
