### PR TITLE
Server-side rewriting of script[src='js/...'] and link rel='import'

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -230,7 +230,7 @@ class HTMLRewriterMixin(StreamingRewriter):
             return ''
 
         unesc_value = self.try_unescape(value)
-        rewritten_value = self.url_rewriter.rewrite(unesc_value, mod)
+        rewritten_value = self.url_rewriter.rewrite(unesc_value, mod, force_abs)
 
         if unesc_value != value and rewritten_value != unesc_value:
             rewritten_value = rewritten_value.replace(unesc_value, value)

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -211,6 +211,10 @@ r"""
 >>> parse('<script type="application/json">{"embed top test": "http://example.com/a/b/c.html"}</script>')
 <script type="application/json">{"embed top test": "http://example.com/a/b/c.html"}</script>
 
+# Script tag with super relative src
+>>> parse('<script src="js/fun.js"></script>')
+<script __wb_orig_src="js/fun.js" src="/web/20131226101010js_/http://example.com/some/path/js/fun.js"></script>
+
 # Script tag + crossorigin + integrity
 >>> parse('<script src="/js/scripts.js" crossorigin="anonymous" integrity="ABC"></script>')
 <script src="/web/20131226101010js_/http://example.com/js/scripts.js" _crossorigin="anonymous" _integrity="ABC"></script>
@@ -260,7 +264,7 @@ r"""
 <html><head><script src="cool.js"></script><script src="/web/20131226101010js_/http://example.com/other.js"></script></head><body>Test</body></html>
 
 >>> parse('<html><script src="other.js"></script></html>', head_insert = '<script src="cool.js"></script>')
-<html><script src="cool.js"></script><script src="other.js"></script></html>
+<html><script src="cool.js"></script><script __wb_orig_src="other.js" src="/web/20131226101010js_/http://example.com/some/path/other.js"></script></html>
 
 >>> parse('<html><head/><body>Test</body></html>', head_insert = '<script src="cool.js"></script>')
 <html><head><script src="cool.js"></script></head><body>Test</body></html>
@@ -310,10 +314,37 @@ r"""
 >>> parse('<link rel="preload" as="video" href="http://example.com/some/other/path">')
 <link rel="preload" as="video" href="/web/20131226101010oe_/http://example.com/some/other/path">
 
+>>> parse('<link rel="preload" as="worker" href="http://example.com/some/other/path">')
+<link rel="preload" as="worker" href="/web/20131226101010js_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="font" href="http://example.com/some/other/path">')
+<link rel="preload" as="font" href="/web/20131226101010oe_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="audio" href="http://example.com/some/other/path">')
+<link rel="preload" as="audio" href="/web/20131226101010oe_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="embed" href="http://example.com/some/other/path">')
+<link rel="preload" as="embed" href="/web/20131226101010oe_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="object" href="http://example.com/some/other/path">')
+<link rel="preload" as="object" href="/web/20131226101010oe_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="track" href="http://example.com/some/other/path">')
+<link rel="preload" as="track" href="/web/20131226101010oe_/http://example.com/some/other/path">
+
+>>> parse('<link rel="preload" as="fetch" href="http://example.com/some/other/path">')
+<link rel="preload" as="fetch" href="/web/20131226101010mp_/http://example.com/some/other/path">
+
 # stylesheet
 >>> parse('<link rel="stylesheet" href="http://example.com/some/other/path">')
 <link rel="stylesheet" href="/web/20131226101010cs_/http://example.com/some/other/path">
 
+# rel='import'
+>>> parse('<link rel="import" href="http://example.com/componemts/app.html">')
+<link rel="import" href="/web/20131226101010mp_/http://example.com/componemts/app.html">
+
+>>> parse('<link rel="import" as="document" href="http://example.com/componemts/app.html">')
+<link rel="import" as="document" href="/web/20131226101010mp_/http://example.com/componemts/app.html">
 
 # doctype
 >>> parse('<!doctype html PUBLIC "public">')

--- a/pywb/rewrite/test/test_url_rewriter.py
+++ b/pywb/rewrite/test/test_url_rewriter.py
@@ -148,6 +148,15 @@
 >>> x = SchemeOnlyUrlRewriter('http://example.com'); x.rebase_rewriter('https://example.com/') == x
 True
 
+# forcing absolute url rewrites
+>>> UrlRewriter('http://example.com/vucht.php', 'http://localhost:8080/live/').rewrite('js/bundle.php?v=1', 'js_', True)
+'/live/js_/http://example.com/js/bundle.php?v=1'
+
+>>> UrlRewriter('http://example.com/vucht.php', 'http://localhost:8080/live/').rewrite('js/bundle.php?v=1', 'js_')
+'js/bundle.php?v=1'
+
+>>> SchemeOnlyUrlRewriter('https://example.com/abc').rewrite('//example.com/abc', force_abs=True)
+'//example.com/abc'
 """
 
 

--- a/pywb/rewrite/url_rewriter.py
+++ b/pywb/rewrite/url_rewriter.py
@@ -40,7 +40,7 @@ class UrlRewriter(object):
         if self.rewrite_opts.get('punycode_links'):
             self.wburl._do_percent_encode = False
 
-    def rewrite(self, url, mod=None):
+    def rewrite(self, url, mod=None, force_abs=False):
         # if special protocol, no rewriting at all
         if url.startswith(self.NO_REWRITE_URI_PREFIX):
             return url
@@ -63,7 +63,7 @@ class UrlRewriter(object):
         if url.startswith(self.REL_SCHEME):
             is_abs = True
             scheme_rel = True
-        elif (not is_abs and
+        elif (not force_abs and not is_abs and
               not url.startswith(self.REL_PATH) and
               self.PARENT_PATH not in url):
             return url
@@ -165,7 +165,7 @@ class IdentityUrlRewriter(UrlRewriter):
     """
     No rewriting performed, return original url
     """
-    def rewrite(self, url, mod=None):
+    def rewrite(self, url, mod=None, force_abs=False):
         return url
 
     def get_new_url(self, **kwargs):
@@ -197,7 +197,7 @@ class SchemeOnlyUrlRewriter(IdentityUrlRewriter):
         else:
             self.opposite_scheme = 'https'
 
-    def rewrite(self, url, mod=None):
+    def rewrite(self, url, mod=None, force_abs=False):
         if url.startswith(self.opposite_scheme + '://'):
             url = self.url_scheme + url[len(self.opposite_scheme):]
 

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1089,6 +1089,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
     }
 
     //============================================
+
     function init_setAttribute_override()
     {
         if (!$wbwindow.Element ||
@@ -1110,6 +1111,12 @@ var _WBWombat = function($wbwindow, wbinfo) {
                     value = rewrite_inline_style(value);
 
                 } else if (should_rewrite_attr(this.tagName, lowername)) {
+                    if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
+                        if (this.hasAttribute("__wb_orig_src")) {
+                            this.removeAttribute("__wb_orig_src");
+                        }
+                        this.__$removedWBOSRC$__ = true;
+                    }
                     if (!this._no_rewrite) {
                         var mod = rwModForElement(this, lowername);
                         value = rewrite_url(value, false, mod);
@@ -1129,7 +1136,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
     {
         if (!$wbwindow.Element ||
             !$wbwindow.Element.prototype ||
-            !$wbwindow.Element.prototype.setAttribute) {
+            !$wbwindow.Element.prototype.getAttribute) {
             return;
         }
 
@@ -1140,6 +1147,13 @@ var _WBWombat = function($wbwindow, wbinfo) {
             var result = orig_getAttribute.call(this, name);
 
             if (should_rewrite_attr(this.tagName, name)) {
+                if (this.tagName === 'script' && !this.__$removedWBOSRC$__) {
+                    var maybeWBOsrc = orig_getAttribute.call(this, '__wb_orig_src');
+                    if (maybeWBOsrc) {
+                        return maybeWBOsrc;
+                    }
+                    this.__$removedWBOSRC$__ = true;
+                }
                 result = extract_orig(result);
             } else if (starts_with(name, "data-") && starts_with(result, VALID_PREFIXES)) {
                 result = extract_orig(result);
@@ -1406,6 +1420,12 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         if (new_value != value) {
+            if (elem.tagName === 'SCRIPT' && !elem.__$removedWBOSRC$__) {
+                if (elem.hasAttribute("__wb_orig_src")) {
+                    elem.removeAttribute("__wb_orig_src");
+                }
+                elem.__$removedWBOSRC$__ = true;
+            }
             wb_setAttribute.call(elem, name, new_value);
             return true;
         }
@@ -1782,6 +1802,12 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 }
                 val = rewrite_url(orig, false, mod);
             } else {
+                if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
+                    if (this.hasAttribute("__wb_orig_src")) {
+                        this.removeAttribute("__wb_orig_src");
+                    }
+                    this.__$removedWBOSRC$__ = true;
+                }
                 val = rewrite_url(orig, false, mod);
             }
 
@@ -2283,7 +2309,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 this.__WB_win_id[source.__WB_id] = source;
 
                 src_id = source.__WB_id;
-                
+
                 window.__WB_source = undefined;
             } else {
                 from = window.WB_wombat_location.origin;

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1147,7 +1147,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             var result = orig_getAttribute.call(this, name);
 
             if (should_rewrite_attr(this.tagName, name)) {
-                if (this.tagName === 'script' && !this.__$removedWBOSRC$__) {
+                if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
                     var maybeWBOsrc = orig_getAttribute.call(this, '__wb_orig_src');
                     if (maybeWBOsrc) {
                         return maybeWBOsrc;

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -153,6 +153,27 @@ var _WBWombat = function($wbwindow, wbinfo) {
         return mod;
     }
 
+    function removeWBOSRC(elem) {
+        if (elem.tagName === 'SCRIPT' && !elem.__$removedWBOSRC$__) {
+            if (elem.hasAttribute('__wb_orig_src')) {
+                elem.removeAttribute('__wb_orig_src');
+            }
+            elem.__$removedWBOSRC$__ = true;
+        }
+    }
+
+    function retrieveWBOSRC(elem) {
+        if (elem.tagName === 'SCRIPT' && !elem.__$removedWBOSRC$__) {
+            var maybeWBOSRC;
+            if (wb_getAttribute) {
+                maybeWBOSRC = wb_getAttribute.call(elem, '__wb_orig_src');
+            } else {
+                maybeWBOSRC = elem.getAttribute('__wb_orig_src');
+            }
+            return maybeWBOSRC;
+        }
+    }
+
     //============================================
     function is_host_url(str) {
         // Good guess that's its a hostname
@@ -703,7 +724,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         this.reload = function() {
             return this._orig_loc.reload();
         }
-       
+
         this.orig_getter = function(prop) {
             return this._orig_loc[prop];
         }
@@ -713,7 +734,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         init_loc_override(this, this.orig_setter, this.orig_getter);
-        
+
         set_loc(this, orig_loc.href);
 
         this.toString = function() {
@@ -1111,12 +1132,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                     value = rewrite_inline_style(value);
 
                 } else if (should_rewrite_attr(this.tagName, lowername)) {
-                    if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
-                        if (this.hasAttribute("__wb_orig_src")) {
-                            this.removeAttribute("__wb_orig_src");
-                        }
-                        this.__$removedWBOSRC$__ = true;
-                    }
+                    removeWBOSRC(this);
                     if (!this._no_rewrite) {
                         var mod = rwModForElement(this, lowername);
                         value = rewrite_url(value, false, mod);
@@ -1147,12 +1163,9 @@ var _WBWombat = function($wbwindow, wbinfo) {
             var result = orig_getAttribute.call(this, name);
 
             if (should_rewrite_attr(this.tagName, name)) {
-                if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
-                    var maybeWBOsrc = orig_getAttribute.call(this, '__wb_orig_src');
-                    if (maybeWBOsrc) {
-                        return maybeWBOsrc;
-                    }
-                    this.__$removedWBOSRC$__ = true;
+                var maybeWBOSRC = retrieveWBOSRC(this);
+                if (maybeWBOSRC) {
+                    return maybeWBOSRC;
                 }
                 result = extract_orig(result);
             } else if (starts_with(name, "data-") && starts_with(result, VALID_PREFIXES)) {
@@ -1423,12 +1436,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         if (new_value != value) {
-            if (elem.tagName === 'SCRIPT' && !elem.__$removedWBOSRC$__) {
-                if (elem.hasAttribute("__wb_orig_src")) {
-                    elem.removeAttribute("__wb_orig_src");
-                }
-                elem.__$removedWBOSRC$__ = true;
-            }
+            removeWBOSRC(elem);
             wb_setAttribute.call(elem, name, new_value);
             return true;
         }
@@ -1805,12 +1813,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 }
                 val = rewrite_url(orig, false, mod);
             } else {
-                if (this.tagName === 'SCRIPT' && !this.__$removedWBOSRC$__) {
-                    if (this.hasAttribute("__wb_orig_src")) {
-                        this.removeAttribute("__wb_orig_src");
-                    }
-                    this.__$removedWBOSRC$__ = true;
-                }
+                removeWBOSRC(this);
                 val = rewrite_url(orig, false, mod);
             }
 
@@ -1890,7 +1893,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         override_attr($wbwindow.HTMLMetaElement.prototype, "content", "mp_");
 
         override_attr($wbwindow.HTMLFormElement.prototype, "action", "mp_");
-     
+
         override_anchor_elem();
 
         var style_proto = $wbwindow.CSSStyleDeclaration.prototype;
@@ -1939,7 +1942,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
         for (var i = 0; i < URL_PROPS.length; i++) {
             save_prop(URL_PROPS[i]);
-        } 
+        }
 
         var anchor_setter = function(prop, value) {
             var func = anchor_orig["set_" + prop];
@@ -2072,7 +2075,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 //}
                 text = rewrite_html(text);
             }
- 
+
             return orig_insertAdjacentHTML.call(this, position, text);
         }
 
@@ -2288,7 +2291,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         var orig = $wbwindow.postMessage;
-        
+
         $wbwindow.__orig_postMessage = orig;
 
         // use this_obj.__WB_source not window to fix google calendar embeds, pm_origin sets this.__WB_source


### PR DESCRIPTION
### Updated html_rewriter.py to account for rewriting of script[src] values that are super relative 
URL requiring change: http://fotopaulmartens.netcam.nl/vucht.php
Script tags with src='x' where x is not absolute, relative, schemeless, or contain `../` resolve (i.e. `js/scplayer.php?camera=paulmartens102129&server=6&port=443&protocol=https`) are resolved by the browser to include a non-js rewrite modifier.
While this is fine in most cases there exists cases where the server does not always send the correct JS MIME type causing JS to not be rewritten as JS. 
In this case PYWB will now turn the "super relative" URL into an absolute URL with the correct rewrite modifier (`js_`) and add an attribute, `__wb_orig_src` to the element containing the unrerwritten URL for wombat.

This case is detected by `html_rewriter.py` using the new method `_not_abs_rel_has_parentp` which contains some duplicated logic from `url_rewriter.py` in order to leave `url_rewriter.py` un-modified.
The check made by `_not_abs_rel_has_parentp` is the opposite of the condition that allowed this to happen before this PR with special consideration to ensure we are not rewriting values not rewritten ever.

### Updated wombat to account for the new rewriting of script[src] 
URL requiring change: http://fotopaulmartens.netcam.nl/vucht.php

Wombat was modified in order to operate correctly under this change when `getAttribute` is used with special consideration to browser resolution of `src, href` attributes when being set.
When the script tag with the `__wb_orig_src` has its `src` attribute changed the `__wb_orig_src` attribute is removed and an internal flag `__$removedWBOSRC$__`, existing on the element itself, is set.
This is done so that further checks for the  `getAttribute` case do not have to made.
In `getAttribute` the value of `__wb_orig_src`  is only returned for script tags if this attribute exists and the  `__$removedWBOSRC$__` flag is false  or undefined.
Removal of  `__wb_orig_src` is handled by `handleWbOrigSrc`.

A minimal working example of this can be found at https://codepen.io/anon/pen/RJbqye.


### Updated html_rewriter.py  link rel='import' rewriting
URL requiring change: https://www.youtube.com
Only change was as check in `_rewrite_link_href` for `rel='import'` and if so `rw_mod = 'mp_'`

### Updated test_html_rewriter.py for super rel script[src] rewriting and link rel='import'
Reasoning: see above