### PR TITLE
html unescape: ensure escaped urls are rewritten (py2 and 3)

### DIFF
--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -88,6 +88,10 @@ r"""
 >>> parse('<input value="&amp;X&amp;&quot;">X</input>')
 <input value="&amp;X&amp;&quot;">X</input>
 
+# Ensure url is rewritten, but is not unescaped
+>>> parse('<a href="http&#x3a;&#x2f;&#x2f;example.com&#x2f;path&#x2f;">')
+<a href="/web/20131226101010/http&#x3a;&#x2f;&#x2f;example.com&#x2f;path&#x2f;">
+
 # Empty values should be ignored
 >>> parse('<input name="foo" value>')
 <input name="foo" value>


### PR DESCRIPTION
Use html unescape only for urls, not all attributes. 
For py3, override html_parser.unescape but store original unescape function, for py2 use HTMLParser.unescape
If unescaped, after rewriting replace with original escaped values if possible.

Sample url: http://public.tableau.com/views/nationalwages21979-2017/Dashboard2?:embed=y&:showVizHome=no&:host_url=https%3A%2F%2Fpublic.tableau.com%2F&:embed_code_version=3&:tabs=no&:toolbar=yes&:animate_transition=yes&:display_static_image=no&:display_spinner=no&:display_overlay=yes&:display_count=yes&publish=yes&:loadOrderID=0&:increment_view_count=no