### PR TITLE
ServiceWorker Rewrite Improvements

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -374,6 +374,9 @@ class RewriteInfo(object):
     def _resolve_text_type(self, text_type):
         mod = self.url_rewriter.wburl.mod
 
+        if mod == 'sw_':
+            return None
+
         if text_type == 'css' and mod == 'js_':
             text_type = 'css'
 
@@ -439,7 +442,7 @@ class RewriteInfo(object):
         return True
 
     def is_url_rw(self):
-        if self.url_rewriter.wburl.mod in ('id_', 'bn_'):
+        if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'sw_'):
             return False
 
         return True

--- a/pywb/rewrite/header_rewriter.py
+++ b/pywb/rewrite/header_rewriter.py
@@ -1,6 +1,7 @@
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.timeutils import datetime_to_http_date
 from datetime import datetime, timedelta
+from six.moves.urllib.parse import urlsplit, urlunsplit
 
 
 #=============================================================================
@@ -93,6 +94,12 @@ class DefaultHeaderRewriter(object):
                     new_headers_list.extend(new_header)
                 else:
                     new_headers_list.append(new_header)
+
+        if self.rwinfo.url_rewriter.wburl.mod == 'sw_':
+            parts = urlsplit(self.rwinfo.url_rewriter.wburl.url)
+            new_url = parts.scheme + '://' + parts.netloc + '/'
+            rw_origin = self.rwinfo.url_rewriter.rewrite(new_url, mod='mp_')
+            new_headers_list.append(('Service-Worker-Allowed', rw_origin))
 
         return StatusAndHeaders(self.http_headers.statusline,
                                 headers=new_headers_list,

--- a/pywb/rewrite/header_rewriter.py
+++ b/pywb/rewrite/header_rewriter.py
@@ -1,7 +1,7 @@
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.timeutils import datetime_to_http_date
 from datetime import datetime, timedelta
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from six.moves.urllib.parse import urlsplit
 
 
 #=============================================================================

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -143,6 +143,18 @@ class TestContentRewriter(object):
         exp = 'function() { WB_wombat_location.href = "http://example.com/"; }'
         assert b''.join(gen).decode('utf-8') == exp
 
+    def test_rewrite_sw_add_headers(self):
+        headers = {'Content-Type': 'application/x-javascript'}
+        content = 'function() { location.href = "http://example.com/"; }'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701sw_')
+
+        assert ('Content-Type', 'application/x-javascript') in headers.headers
+        assert ('Service-Worker-Allowed', 'http://localhost:8080/prefix/201701mp_/http://example.com/') in headers.headers
+
+        exp = 'function() { location.href = "http://example.com/"; }'
+        assert b''.join(gen).decode('utf-8') == exp
+
     def test_banner_only_no_cookie_rewrite(self):
         headers = {'Set-Cookie': 'foo=bar; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Path=/',
                    'Content-Type': 'text/javascript'}

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1361,9 +1361,12 @@ var _WBWombat = function($wbwindow, wbinfo) {
         var orig_register = $wbwindow.ServiceWorkerContainer.prototype.register;
 
         $wbwindow.ServiceWorkerContainer.prototype.register = function(scriptURL, options) {
-            scriptURL = rewrite_url(scriptURL, false, "id_");
+            scriptURL = new URL(scriptURL, $wbwindow.document.baseURI).href;
+            scriptURL = rewrite_url(scriptURL, false, "sw_");
             if (options && options.scope) {
-                options.scope = rewrite_url(options.scope, false, "id_");
+                options.scope = rewrite_url(options.scope, false, "mp_");
+            } else {
+                options = {scope: rewrite_url("/", false, "mp_")};
             }
             return orig_register.call(this, scriptURL, options);
         }

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -38,9 +38,7 @@
 
   if (window && window._WBWombat && !window._wb_wombat) {
     window._wb_wombat = new _WBWombat(window, wbinfo);
-  } else if (window._wb_wombat) {
-    window._wb_wombat.init_paths(wbinfo);
-  } else {
+  } else if (!window._wb_wombat) {
     console.warn("_wb_wombat missing!");
   }
 </script>


### PR DESCRIPTION
Experimental SW rewriting fixes, attempts to address issues raised in #323:
- ServiceWorker override resolved to absolute url before rewriting to use the `sw_` modifier.
- `sw_` modifier is similar to `id_`, but adds `Service-Worker-Allowed` to domain root
- wombat: service worker override rewrites origin, setting a default origin to domain root with mp_ modifier (to match Service-Worker-Allowed header)
- wombat init: don't call wombat init_paths if wombat already inited, as may happen from imported document.