### PR TITLE
Added FontFace to wombat overrides

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2074,6 +2074,30 @@ var _WBWombat = function($wbwindow, wbinfo) {
     }
 
     //============================================
+    function initFontFaceOverride ($wbwindow) {
+        if (!$wbwindow.FontFace || $wbwindow.FontFace.__wboverriden__) {
+            return;
+        }
+        // per https://drafts.csswg.org/css-font-loading/#FontFace-interface and Chrome, FF, Opera Support
+        var origFontFace = $wbwindow.FontFace;
+        $wbwindow.FontFace = (function (FontFace) {
+            return function (family, source, descriptors) {
+                var rwSource = source;
+                if (source != null) {
+                    if (typeof source !== 'string') {
+                        source = source.toString(); // is CSSOMString or ArrayBuffer or ArrayBufferView
+                    }
+                    rwSource = rewrite_inline_style(source);
+                }
+                return new FontFace(family, rwSource, descriptors);
+            }
+        })($wbwindow.FontFace);
+        $wbwindow.FontFace.prototype = origFontFace.prototype;
+        Object.defineProperty($wbwindow.FontFace.prototype, "constructor", {value: $wbwindow.FontFace});
+        $wbwindow.FontFace.__wboverriden__ = true;
+    }
+
+    //============================================
     function init_wombat_loc(win) {
 
         if (!win || (win.WB_wombat_location && win.document.WB_wombat_location)) {
@@ -3353,6 +3377,9 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
             // Audio
             init_audio_override();
+
+            // FontFace
+            initFontFaceOverride($wbwindow);
 
             // Worker override (experimental)
             init_web_worker_override();


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-font-loading/#FontFace-interface
Browser Support: Chrome + Android >= 35, FireFox + Android >= 41 
URL requiring change: [http://public.tableau.com/views/nationalwages21979-2017/Dashboard2](http://public.tableau.com/views/nationalwages21979-2017/Dashboard2?:embed=y&:showVizHome=no&:host_url=https%3A%2F%2Fpublic.tableau.com%2F&:embed_code_version=3&:tabs=no&:toolbar=yes&:animate_transition=yes&:display_static_image=no&:display_spinner=no&:display_overlay=yes&:display_count=yes&publish=yes&:loadOrderID=0&:increment_view_count=no)
Minimal Working Example: https://googlechrome.github.io/samples/font-face-set/

The `FontFace` override follows the override convent of the `Audio` override and the override can be summarized as:   
- If the source argument is not null or undefined
  1. check the source to see if it is not a string and if so call convert it to a string using  `toString` 
  2. assign the rwSource variable to the results of rewriting `source` using `rewrite_inline_style`
- Return a new instance of the `FontFace` interface using `rwSource` in place of source 