### PR TITLE
Add rewriting of SVG Filter attribute

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1395,7 +1395,10 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
         var new_value;
 
-        if (name == "style") {
+        if (name === 'filter') {
+            // for svg filter attribute which is url(...)
+            new_value = rewrite_inline_style(value);
+        } else if (name == "style") {
             new_value = rewrite_style(value);
         } else if (name == "srcset") {
             new_value = rewrite_srcset(value);
@@ -1570,6 +1573,8 @@ var _WBWombat = function($wbwindow, wbinfo) {
             changed = rewrite_script(elem);
         } else if (elem.tagName == "image") {
             changed = rewrite_attr(elem, "xlink:href");
+        } else if (elem instanceof SVGElement && elem.hasAttribute('filter')) {
+            changed = rewrite_attr(elem, 'filter');
         } else {
             changed = rewrite_attr(elem, "src");
             changed = rewrite_attr(elem, "srcset") || changed;


### PR DESCRIPTION
URL requiring change: http://fotopaulmartens.netcam.nl/vucht.php
Spec: https://www.w3.org/TR/SVG11/filters.html#FilterProperty
MDN Link: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/filter

The svg filter attribute is used to apply an `effect` to an element and has the value of `funciri | none | inherit` where `funciri = Functional notation for an IRI: "url(" <IRI> ")".`
There are some cases when the value is an `funciri` that is full URI (i.e `http://example.com#a1`) and in this case will cause a CSP violation (`Refused to frame`).

The rewriting of this attribute is handled in `rewrite_elem` via `rewrite_attr` and can be summarized as:
 - if the element in question is an instance of `SVGElement` and has the `filter` attribute
   1. rewrite using `rewrite_attr` using `rewrite_inline_style`
- Otherwise do nothing

It should be noted that this PR is dependent on PR https://github.com/webrecorder/pywb/pull/334 as the changes provided by that PR allow the these changes to be view in action using the `URL requiring change` 