### PR TITLE
slash redirects: if a capture ends with '/' (with or without a query)…

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -201,6 +201,18 @@ class RewriterApp(object):
         except (ValueError, TypeError):
             pass
 
+    def send_redirect(self, new_path, url_parts, urlrewriter):
+        scheme, netloc, path, query, frag = url_parts
+        path = new_path
+        url = urlunsplit((scheme, netloc, path, query, frag))
+        resp = WbResponse.redir_response(urlrewriter.rewrite(url),
+                                         '307 Temporary Redirect')
+
+        if self.enable_memento:
+            resp.status_headers['Link'] = MementoUtils.make_link(url, 'original')
+
+        return resp
+
     def render_content(self, wb_url, kwargs, environ):
         wb_url = wb_url.replace('#', '%23')
         wb_url = WbUrl(wb_url)
@@ -238,16 +250,7 @@ class RewriterApp(object):
 
         url_parts = urlsplit(wb_url.url)
         if not url_parts.path:
-            scheme, netloc, path, query, frag = url_parts
-            path = '/'
-            url = urlunsplit((scheme, netloc, path, query, frag))
-            resp = WbResponse.redir_response(urlrewriter.rewrite(url),
-                                             '307 Temporary Redirect')
-
-            if self.enable_memento:
-                resp.status_headers['Link'] = MementoUtils.make_link(url, 'original')
-
-            return resp
+            return self.send_redirect('/', url_parts, urlrewriter)
 
         self.unrewrite_referrer(environ, full_prefix)
 
@@ -288,14 +291,27 @@ class RewriterApp(object):
             details = dict(args=kwargs, error=error)
             raise UpstreamException(r.status_code, url=wb_url.url, details=details)
 
+        cdx = CDXObject(r.headers.get('Warcserver-Cdx').encode('utf-8'))
+
+        cdx_url_parts = urlsplit(cdx['url'])
+
+        if cdx_url_parts.path.endswith('/') and not url_parts.path.endswith('/'):
+            # add trailing slash
+            new_path = url_parts.path + '/'
+
+            try:
+                r.raw.close()
+            except:
+                pass
+
+            return self.send_redirect(new_path, url_parts, urlrewriter)
+
         stream = BufferedReader(r.raw, block_size=BUFF_SIZE)
         record = self.loader.parse_record_stream(stream,
                                                  ensure_http_headers=True)
 
         memento_dt = r.headers.get('Memento-Datetime')
         target_uri = r.headers.get('WARC-Target-URI')
-
-        cdx = CDXObject(r.headers.get('Warcserver-Cdx').encode('utf-8'))
 
         #cdx['urlkey'] = urlkey
         #cdx['timestamp'] = http_date_to_timestamp(memento_dt)

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -10,10 +10,10 @@ from pywb.manager.manager import main as wb_manager
 
 
 # ============================================================================
-class TestSelfRedirect(CollsDirMixin, BaseConfigTest):
+class TestRedirects(CollsDirMixin, BaseConfigTest):
     @classmethod
     def setup_class(cls):
-        super(TestSelfRedirect, cls).setup_class('config_test.yaml')
+        super(TestRedirects, cls).setup_class('config_test.yaml')
 
     def create_redirect_record(self, url, redirect_url, timestamp):
         warc_headers = {}
@@ -75,8 +75,8 @@ class TestSelfRedirect(CollsDirMixin, BaseConfigTest):
 
         self.writer.write_record(rec)
 
-    def init_warc(self, filename, coll):
-        filename = os.path.join(self.root_dir, filename)
+    def test_init_1(self):
+        filename = os.path.join(self.root_dir, 'redir.warc.gz')
         with open(filename, 'wb') as fh:
             self.writer = WARCWriter(fh, gzip=True)
 
@@ -84,15 +84,11 @@ class TestSelfRedirect(CollsDirMixin, BaseConfigTest):
             redirect = self.create_redirect_record('https://example.com/', 'https://www.example.com/', '201806026101112')
             response = self.create_response_record('https://www.example.com/', '201806026101112', 'Some Text')
 
-        wb_manager(['init', coll])
+        wb_manager(['init', 'redir'])
 
-        wb_manager(['add', coll, filename])
-
-    def test_self_redir_init(self):
-        self.init_warc('redirect.warc.gz', 'redir')
+        wb_manager(['add', 'redir', filename])
 
         assert os.path.isfile(os.path.join(self.root_dir, self.COLLS_DIR, 'redir', 'indexes', 'index.cdxj'))
-
 
     def test_self_redir_1(self, fmod):
         res = self.get('/redir/201806026101112{0}/https://example.com/', fmod)
@@ -101,8 +97,36 @@ class TestSelfRedirect(CollsDirMixin, BaseConfigTest):
 
         assert res.text == 'Some Text'
 
+    def test_redir_init_slash(self):
+        filename = os.path.join(self.root_dir, 'redir-slash.warc.gz')
+        with open(filename, 'wb') as fh:
+            self.writer = WARCWriter(fh, gzip=True)
 
+            response = self.create_response_record('https://www.example.com/sub/path/', '201806026101112', 'Sub Path Data')
 
+            response = self.create_response_record('https://www.example.com/sub/path/?foo=bar', '201806026101112', 'Sub Path Data Q')
+
+        wb_manager(['add', 'redir', filename])
+
+    def test_redir_slash(self, fmod):
+        res = self.get('/redir/201806026101112{0}/https://example.com/sub/path', fmod, status=307)
+
+        assert res.headers['Location'].endswith('/redir/201806026101112{0}/https://example.com/sub/path/'.format(fmod))
+        res = res.follow()
+
+        assert res.status_code == 200
+
+        assert res.text == 'Sub Path Data'
+
+    def test_redir_slash_with_query(self, fmod):
+        res = self.get('/redir/201806026101112{0}/https://example.com/sub/path?foo=bar', fmod, status=307)
+
+        assert res.headers['Location'].endswith('/redir/201806026101112{0}/https://example.com/sub/path/?foo=bar'.format(fmod))
+        res = res.follow()
+
+        assert res.status_code == 200
+
+        assert res.text == 'Sub Path Data Q'
 
 
 


### PR DESCRIPTION
…, and requested url does not end in '/',

redirect to '/' version, fixes #344