### PR TITLE
Facebook and Web Worker fixes

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -381,7 +381,7 @@ class RewriteInfo(object):
     def _resolve_text_type(self, text_type):
         mod = self.url_rewriter.wburl.mod
 
-        if mod == 'sw_':
+        if mod == 'sw_' or mod == 'wkr_':
             return None
 
         if text_type == 'css' and mod == 'js_':
@@ -449,7 +449,7 @@ class RewriteInfo(object):
         return True
 
     def is_url_rw(self):
-        if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'sw_'):
+        if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'sw_', 'wkr_'):
             return False
 
         return True

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -155,6 +155,15 @@ class TestContentRewriter(object):
         exp = 'function() { location.href = "http://example.com/"; }'
         assert b''.join(gen).decode('utf-8') == exp
 
+    def test_rewrite_worker(self):
+        headers = {'Content-Type': 'application/x-javascript'}
+        content = 'importScripts("http://example.com/js.js")'
+
+        rwheaders, gen, is_rw = self.rewrite_record(headers, content, ts='201701wrk_')
+
+        exp = 'importScripts("http://example.com/js.js")'
+        assert b''.join(gen).decode('utf-8') == exp
+
     def test_banner_only_no_cookie_rewrite(self):
         headers = {'Set-Cookie': 'foo=bar; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Path=/',
                    'Content-Type': 'text/javascript'}

--- a/pywb/static/ww_rw.js
+++ b/pywb/static/ww_rw.js
@@ -21,9 +21,9 @@ function WBWombat(info) {
                 async = true;
             }
 
-            result = orig.call(this, method, url, async, user, password);
+            var result = orig.call(this, method, url, async, user, password);
 
-            if (url.indexOf("data:") != 0) {
+            if (url.indexOf('data:') !== 0) {
                 this.setRequestHeader('X-Pywb-Requested-With', 'XMLHttpRequest');
             }
         }
@@ -32,6 +32,55 @@ function WBWombat(info) {
     }
 
     init_ajax_rewrite();
-}
 
+    function rewriteArgs(argsObj) {
+        // recreate the original arguments object just with URLs rewritten
+        var newArgObj = {length: argsObj.length};
+        for (var i = 0; i < argsObj.length; i++) {
+            var arg = argsObj[i];
+            newArgObj[i] = rewrite_url(arg);
+        }
+        return newArgObj;
+    }
+
+    var origImportScripts = self.importScripts;
+    self.importScripts = function importScripts() {
+        // rewrite the arguments object and call original function via fn.apply
+        var rwArgs = rewriteArgs(arguments);
+        return origImportScripts.apply(this, rwArgs);
+    };
+
+    if (self.fetch != null) {
+        // this fetch is Worker.fetch
+        var orig_fetch = self.fetch;
+        self.fetch = function(input, init_opts) {
+            var inputType = typeof(input);
+            if (inputType === 'string') {
+                input = rewrite_url(input);
+            } else if (inputType === 'object' && input.url) {
+                var new_url = rewrite_url(input.url);
+                if (new_url !== input.url) {
+                    input = new Request(new_url, input);
+                }
+            }
+            init_opts = init_opts || {};
+            init_opts['credentials'] = 'include';
+            return orig_fetch.call(this, input, init_opts);
+        };
+    }
+
+    var oEval = self.eval;
+    self.eval = function(str) {
+        try {
+            return oEval(str);
+        } catch (e) {
+            // escape hatch for some sites
+            // https://spotify---bastille.appspot.com completely broken without
+            if (e.toString().indexOf('Window is not defined')) {
+                self.Window = self;
+            }
+        }
+        return oEval(str);
+    };
+}
 


### PR DESCRIPTION
URLs requiring change: https://www.facebook.com/ and https://spotify---bastille.appspot.com/
#### Wombat changes
Facebook polyfills requestAnimationFrame and when we return the polyfill function bound to window they can detect that and complain. 
The fix is to not return a bound function when `prop` is `requestAnimationFrame` **IFF** Function.toString does not return `"native code"`
- default_proxy_get improvement: Facebook fix: if prop is requestAnimationFrame (raf) and it was polyfilled by FB do not bind

Both Facebook, the spotify app and many other websites use `Web Workers (Worker)` that are created not using blobs; likewise with `ShardWorker`. 
The previous override only handled the blob case for `Worker` and thus any other use case was not handled properly.
The fix is to expand on the rewriting of worker urls for both `Worker` and `SharedWorker`. 
Includes a new override for `SharedWorker` and introduces a new modifier `wkr_`.
- improved worker rewriting: updated worker rewriting handles non-blob urls, added SharedWorker override

#### ww_rw.js changes
The min-rewriting system for workers was updated to provide a more complete system that now handles 
`importScripts`, `Worker.fetch`, and an `eval` edge case unique to the spotify app.   
- updated to be a much more complete rewriting system: overrides for importScripts, fetch, and eval "hack"

#### content_rewriter.py changes
In order to ensure the setup for the full client-side rewriting system is not included in worker code the `wkr_` modifier was introduced.
This modifier behaves exactly like `sw_`.
 - added `wkr_` mod for handling Worker/SharedWorker, follows convention of service worker

#### test_content_rewriter.py changes
The tests for `content_rewriter.py` was updated for the introduction of the new modifer `wkr_`.
- added test for content rewriting of Worker/SharedWorker