### PR TITLE
Improved Web Worker and SharedWorker rewrite system

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -381,7 +381,7 @@ class RewriteInfo(object):
     def _resolve_text_type(self, text_type):
         mod = self.url_rewriter.wburl.mod
 
-        if mod == 'sw_':
+        if mod == 'sw_' or mod == 'wkr_':
             return None
 
         if text_type == 'css' and mod == 'js_':
@@ -449,7 +449,7 @@ class RewriteInfo(object):
         return True
 
     def is_url_rw(self):
-        if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'sw_'):
+        if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'sw_', 'wkr_'):
             return False
 
         return True

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -155,6 +155,15 @@ class TestContentRewriter(object):
         exp = 'function() { location.href = "http://example.com/"; }'
         assert b''.join(gen).decode('utf-8') == exp
 
+    def test_rewrite_worker(self):
+        headers = {'Content-Type': 'application/x-javascript'}
+        content = 'importScripts("http://example.com/js.js")'
+
+        rwheaders, gen, is_rw = self.rewrite_record(headers, content, ts='201701wkr_')
+
+        exp = 'importScripts("http://example.com/js.js")'
+        assert b''.join(gen).decode('utf-8') == exp
+
     def test_banner_only_no_cookie_rewrite(self):
         headers = {'Set-Cookie': 'foo=bar; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Path=/',
                    'Content-Type': 'text/javascript'}


### PR DESCRIPTION
**Replaces 1/2 of PR #349**

#### Wombat changes
The spotify app and many other websites use `Web Workers (Worker)` that are created not using blobs; likewise with `ShardWorker`. 
The previous override only handled the blob case for `Worker` and thus any other use case was not handled properly.
The fix is to expand on the rewriting of worker urls for both `Worker` and `SharedWorker`. 
Includes a new override for `SharedWorker` and introduces a new modifier `wkr_`.
- improved worker rewriting: updated worker rewriting handles non-blob urls, added SharedWorker override

#### ww_rw.js changes
The min-rewriting system for workers was updated to provide a more complete system that now handles 
`importScripts`, `Worker.fetch`, and an `eval` edge case unique to the spotify app.   
- updated to be a much more complete rewriting system: overrides for importScripts, fetch, and eval "hack"

#### content_rewriter.py changes
In order to ensure the setup for the full client-side rewriting system is not included in worker code the `wkr_` modifier was introduced.
This modifier behaves exactly like `sw_`.
 - added `wkr_` mod for handling Worker/SharedWorker, follows convention of service worker

#### test_content_rewriter.py changes
The tests for `content_rewriter.py` was updated for the introduction of the new modifer `wkr_`.
- added test for content rewriting of Worker/SharedWorker