### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+
+---
+## Describe the bug
+<!--- A clear and concise description of what the bug is. --->
+
+## Steps to reproduce the bug
+<!--- Help us fix this bug is by providing steps to reproduce! -->
+
+
+## Expected behavior
+<!--- A clear and concise description of what you expected to happen. --->
+
+## Screenshots
+<!--- If applicable, add screenshots to help explain your problem. --->
+
+## Environment
+<!--- Include specific details about the environment the issue occurred in. --->
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+## Additional context
+<!--- Add any other context about the problem here.  --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea to improve this project!
+
+---
+<!--- Delete where not applicable --->
+## Is your feature request related to a problem? Please describe.
+<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+
+## Describe the solution you'd like
+<!--- A clear and concise description of what you want to happen. -->
+
+
+## Describe alternatives you've considered
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
+## Additional context
+<!--- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/replay_issue.md
+++ b/.github/ISSUE_TEMPLATE/replay_issue.md
@@ -1,0 +1,30 @@
+---
+name: Replay Issue
+about: Can not replay a specific web page? Tell us about it!
+
+---
+## Expected behavior
+<!--- Tell us about the page and how it should replay -->
+
+
+## What actually happened
+<!--- Tell us about how we failed to replay the page -->
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+## Browser
+<!--- Tell us about the browser you used to view the page. -->
+<!--- Choose either desktop or smartphone. -->
+**Desktop (please complete the following information):**
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- Delete where not applicable --->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+<!--- Include Any URLs requiring this change. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Replay fix (fixes a replay specific issue)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added or updated tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.5'
+__version__ = '2.0.4'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 

--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 


### PR DESCRIPTION
This PR adds github issue and pr templates in order to help streamline the creation of both issues and pull requests.

### Issue Templates
When a user goes to open a new issue for this project they will have the choice to select from three templates or use the default blank slate issue. 
![issuetemplates](https://user-images.githubusercontent.com/8648317/42050141-23c700ac-7ad6-11e8-8781-f47a1d48cd76.png)

### Pull Request Template
Designed for quick identification of the information pertaining to the particulars of the PR  