### PR TITLE
RegexRewriter Optimization

### DIFF
--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 

--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -272,8 +272,7 @@ class JSWombatProxyRewriter(RegexRewriter):
 
 # =================================================================
 class JSNoneRewriter(RegexRewriter):
-    def __init__(self, rewriter, rules=[]):
-        super(JSNoneRewriter, self).__init__(rewriter, rules)
+    pass
 
 
 # =================================================================

--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -54,7 +54,7 @@ class RxRules(object):
         if not extra_rules:
             return self.rules, self.regex
 
-        all_rules = self.rules + extra_rules
+        all_rules = extra_rules + self.rules
         regex = self.compile_rules(all_rules)
         return all_rules, regex
 

--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -63,10 +63,10 @@ class RxRules(object):
 class JSWombatProxyRules(RxRules):
     def __init__(self):
         local_init_func = '\nvar {0} = function(name) {{\
-    return (self._wb_wombat && self._wb_wombat.local_init &&\
-     self._wb_wombat.local_init(name)) || self[name]; }};\n\
-    if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
-    {{\n'
+return (self._wb_wombat && self._wb_wombat.local_init &&\
+self._wb_wombat.local_init(name)) || self[name]; }};\n\
+if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
+{{\n'
 
         local_init_func_name = '_____WB$wombat$assign$function_____'
 
@@ -240,9 +240,9 @@ class JSWombatProxyRewriter(RegexRewriter):
     rules_factory = JSWombatProxyRules()
 
     def __init__(self, rewriter, extra_rules=None):
-        super(JSWombatProxyRewriter, self).__init__(rewriter, extra_rules=extra_rules,
-                                                    first_buff=self.rules_factory.first_buff)
+        super(JSWombatProxyRewriter, self).__init__(rewriter, extra_rules=extra_rules)
 
+        self.first_buff = self.rules_factory.first_buff
         self.last_buff = self.rules_factory.last_buff
         self.local_objs = self.rules_factory.local_objs
 

--- a/pywb/rewrite/rewrite_dash.py
+++ b/pywb/rewrite/rewrite_dash.py
@@ -58,7 +58,7 @@ class RewriteDASH(BufferedRewriter):
 
 
 # ============================================================================
-def rewrite_fb_dash(string):
+def rewrite_fb_dash(string, *args):
     DASH_SPLIT = r'\n",dash_prefetched_representation_ids:'
     inx = string.find(DASH_SPLIT)
     if inx < 0:

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -437,8 +437,8 @@ def parse(data, head_insert=None, urlrewriter=urlrewriter, parse_comments=False,
                           parse_comments=parse_comments)
 
     if js_proxy:
-        parser.js_rewriter.first_buff = '{ '
-        parser.js_rewriter.last_buff = ' }'
+        parser.js_rewriter.rules_factory.first_buff = '{ '
+        parser.js_rewriter.rules_factory.last_buff = ' }'
 
     if six.PY2 and isinstance(data, six.text_type):
         data = data.encode('utf-8')

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -437,8 +437,8 @@ def parse(data, head_insert=None, urlrewriter=urlrewriter, parse_comments=False,
                           parse_comments=parse_comments)
 
     if js_proxy:
-        parser.js_rewriter.rules_factory.first_buff = '{ '
-        parser.js_rewriter.rules_factory.last_buff = ' }'
+        parser.js_rewriter.first_buff = '{ '
+        parser.js_rewriter.last_buff = ' }'
 
     if six.PY2 and isinstance(data, six.text_type):
         data = data.encode('utf-8')

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -3,7 +3,7 @@ r"""
 # Custom Regex
 #=================================================================
 # Test https->http converter (other tests below in subclasses)
->>> RegexRewriter(urlrewriter, [(RegexRewriter.HTTPX_MATCH_STR, RegexRewriter.remove_https, 0)]).rewrite('a = https://example.com; b = http://example.com; c = https://some-url/path/https://embedded.example.com')
+>>> RegexRewriter(urlrewriter, [(RxRules.HTTPX_MATCH_STR, RxRules.remove_https, 0)]).rewrite('a = https://example.com; b = http://example.com; c = https://some-url/path/https://embedded.example.com')
 'a = http://example.com; b = http://example.com; c = http://some-url/path/http://embedded.example.com'
 
 
@@ -101,7 +101,7 @@ r"""
 '"/web/20131010/\\\\/\\\\/example.com/"'
 
 # custom rules added
->>> _test_js('window.location = "http://example.com/abc.html"; some_func(); ', [('some_func\(\).*', RegexRewriter.format('/*{0}*/'), 0)])
+>>> _test_js('window.location = "http://example.com/abc.html"; some_func(); ', [('some_func\(\).*', RxRules.format('/*{0}*/'), 0)])
 'window.WB_wombat_location = "/web/20131010/http://example.com/abc.html"; /*some_func(); */'
 
 # scheme-agnostic
@@ -274,7 +274,7 @@ r"""
 
 #=================================================================
 from pywb.rewrite.url_rewriter import UrlRewriter
-from pywb.rewrite.regex_rewriters import RegexRewriter, JSRewriter, CSSRewriter, XMLRewriter
+from pywb.rewrite.regex_rewriters import RegexRewriter, JSRewriter, CSSRewriter, XMLRewriter, RxRules
 from pywb.rewrite.regex_rewriters import JSWombatProxyRewriter
 
 


### PR DESCRIPTION
- Split RxRewriter rules into separate class hierarchy, inited once
- Each RegexRewriter has a 'rules factory' which generates the rules for the rewriter
- If extra rules provided, recompile with dynamic rules, otherwise return existing fixed rules
- Avoids recompiling rules rx for each rewriter (unless dynamic rules used), instead store rules object per rewriter type