### PR TITLE
Include pywb based webrecorder-tests to travis ci setup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,16 @@ os:
   - linux
 
 addons:
+  apt:
+    packages:
+      # This is required to run new chrome on old trusty
+      - libnss3
+
+env:
+  - WR_TEST=no
+  - WR_TEST=yes
+
+addons:
   sauce_connect: true
 
 cache:
@@ -16,25 +26,25 @@ cache:
     - $HOME/.cache/pip
     - node_modules
 
-sudo: false
+sudo: true
 
 install:
-  #- pip install boto certauth youtube-dl
-  #- pip install git+https://github.com/esnme/ultrajson.git
-  - python setup.py -q install
-  - pip install -r extra_requirements.txt
-  - pip install coverage pytest-cov coveralls
-  - pip install codecov
-  - npm install
+  - ./.travis/install.sh
 
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 script:
-  - python setup.py test
-  - cd karma-tests && make test && cd ..
+  - ./.travis/test.sh
 
 after_success:
   - codecov
+
+matrix:
+  exclude:
+    - env: WR_TEST=yes
+      python: "2.7"
+    - env: WR_TEST=yes
+      python: "3.5"
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+python setup.py -q install
+pip install -r extra_requirements.txt
+pip install coverage pytest-cov coveralls
+pip install codecov
+npm install
+
+if [ "$WR_TEST" = "yes" ]; then
+    git clone https://github.com/webrecorder/webrecorder-tests.git
+    cd webrecorder-tests
+    pip install --upgrade -r requirements.txt
+    ./bootstrap.sh
+fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ "$WR_TEST" = "no" ]; then
+    python setup.py test
+    cd karma-tests && make test && cd ..
+else
+    cd webrecorder-tests
+    INTRAVIS=1 pytest -m "pywbtest"
+fi


### PR DESCRIPTION
This pr is to include the replay tests provided by [webrecorder-tests](https://github.com/webrecorder/webrecorder-tests/tree/develop) into pywb's ci workflow.

## Changes
### Updated .travis.yml file for including webrecorder-tests
The `.travis.yml` file was updated to include a matrix based off the `WR_TEST` environment variable set to true and false.
The build matrix excludes python 2.7 and 3.5 when `WR_TEST=true` because webrecorder-tests is python 3.6 based.
When python 3.6 and `WR_TEST=true` we use the apt addon `libnss3` to allow for browser based testing on the `trusty` linux distribution.

### Added .travis directory that includes two scripts: install.sh and test.sh.
The two scripts in the .travis directory are to support the additional testing via webrecorder-tests.

The `install.sh` script contains the exact commands that were originally contained in the `install` field of `.travis.yml`. 
with the addition of the installation and setup steps required for webrecorder-tests integration.
The webrecorder-tests integration portion of the `install.sh` script  only happens when `WR_TEST=true`.

Likewise the `test.sh` script contains the exact command originally found in the `script` field of `.travis.yml`. 
The additions here were to run pywb's integration tests when `WR_TEST=false` otherwise only run the webrecorder-tests pywb tests.
