### PR TITLE
Page title and favicon display

### DIFF
--- a/pywb/static/wb_frame.js
+++ b/pywb/static/wb_frame.js
@@ -109,6 +109,23 @@ function ContentFrame(content_info) {
 
     this.handle_message = function(state) {
         var type = state.wb_type;
+        
+        if (type === 'load') {
+			window.document.title = state.title + ' ' + state.ts;
+			var head = document.querySelector('head');
+			var oldLink = document.querySelectorAll("link[rel*='icon']");
+			for (var i = 0; i < oldLink.length; i++) {
+				head.removeChild(oldLink[i]);
+			}
+			var len = state.icons.length;
+			for (var i = 0; i < len; i++) {
+				var icon = state.icons[i];
+				var link = document.createElement('link');
+				link.rel = icon.rel;
+				link.href = icon.href;
+				head.appendChild(link);
+			}
+		}
 
         if (type == "load" || type == "replace-url") {
             this.set_url(state);

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -3583,15 +3583,26 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 return;
             }
 
-            var message = {
-                       "url": $wbwindow.WB_wombat_location.href,
-                       "ts": wbinfo.timestamp,
-                       "request_ts": wbinfo.request_ts,
-                       "is_live": wbinfo.is_live,
-                       "title": $wbwindow.document ? $wbwindow.document.title : "",
-                       "readyState": $wbwindow.document.readyState,
-                       "wb_type": "load"
-            }
+            var icons = [];
+			var hicons = $wbwindow.document.querySelectorAll("link[rel*='icon']");
+			for (var i = 0; i < hicons.length; i++) {
+				var hicon = hicons[i];
+				icons.push({
+					rel: hicon.rel,
+					href: wb_getAttribute.call(hicon, 'href')
+				})
+			}
+
+			var message = {
+				"icons": icons,
+				"url": $wbwindow.WB_wombat_location.href,
+				"ts": wbinfo.timestamp,
+				"request_ts": wbinfo.request_ts,
+				"is_live": wbinfo.is_live,
+				"title": $wbwindow.document ? $wbwindow.document.title : "",
+				"readyState": $wbwindow.document.readyState,
+				"wb_type": "load"
+			}
 
             send_top_message(message);
         }

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -22,6 +22,37 @@ html, body
 <iframe id="replay_iframe" frameborder="0" seamless="seamless" scrolling="yes" class="wb_iframe"></iframe>
 </div>
 <script>
+	
+	function messageListener (event) {
+		
+		var message = event.data;
+		if (message.wb_type === 'load') {
+			console.log('--- message : ', message);
+			
+			document.title = message.title;
+			
+			var iframe = document.querySelector('#replay_iframe');
+			var frame_dom = iframe.contentWindow.document;
+			
+			var iconDocumentList = document.querySelectorAll("link[rel*='icon']");
+			var iconFrameList = frame_dom.querySelectorAll("link[rel*='icon']");
+			
+			if (iconFrameList.length != 0) {
+				for (var i = 0; i < iconDocumentList.length; i++)
+				{
+					document.getElementsByTagName('head')[0].removeChild(iconDocumentList[i]);
+				}
+			}
+      
+			for (var i = 0; i < iconFrameList.length; i++)
+			{
+				document.getElementsByTagName('head')[0].appendChild(iconFrameList[i]);
+			}
+		}
+	}
+
+	window.addEventListener('message', messageListener, false);
+  
   var cframe = new ContentFrame({"url": "{{ url }}" + window.location.hash,
                                  "prefix": "{{ wb_prefix }}",
                                  "request_ts": "{{ wb_url.timestamp }}",

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -22,37 +22,6 @@ html, body
 <iframe id="replay_iframe" frameborder="0" seamless="seamless" scrolling="yes" class="wb_iframe"></iframe>
 </div>
 <script>
-	
-	function messageListener (event) {
-		
-		var message = event.data;
-		if (message.wb_type === 'load') {
-			console.log('--- message : ', message);
-			
-			document.title = message.title;
-			
-			var iframe = document.querySelector('#replay_iframe');
-			var frame_dom = iframe.contentWindow.document;
-			
-			var iconDocumentList = document.querySelectorAll("link[rel*='icon']");
-			var iconFrameList = frame_dom.querySelectorAll("link[rel*='icon']");
-			
-			if (iconFrameList.length != 0) {
-				for (var i = 0; i < iconDocumentList.length; i++)
-				{
-					document.getElementsByTagName('head')[0].removeChild(iconDocumentList[i]);
-				}
-			}
-      
-			for (var i = 0; i < iconFrameList.length; i++)
-			{
-				document.getElementsByTagName('head')[0].appendChild(iconFrameList[i]);
-			}
-		}
-	}
-
-	window.addEventListener('message', messageListener, false);
-  
   var cframe = new ContentFrame({"url": "{{ url }}" + window.location.hash,
                                  "prefix": "{{ wb_prefix }}",
                                  "request_ts": "{{ wb_url.timestamp }}",


### PR DESCRIPTION
Favicon display in no-proxy mode with framed_replay: true.

When "iframe": "#replay_iframe", the icon of the tab in question is not visible (or a wrong icon is displayed provided from cache memory ) because of the presence of an added frame (#replay_iframe).

Indeed, the main frame can not get the right favicon in the presence of another sub frame (#replay_iframe).

The modifcation allows to get the replay_iframe favicon and apply it on the main frame to be correctly displayed in the tab.

( see Issue #342)

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
