### PR TITLE
Advanced Srcset and Style Sheet Containing Media Queries Preservation

### DIFF
--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -127,6 +127,8 @@ describe('WombatJS', function () {
                 wbinfo = {
                     wombat_opts: {},
                     wombat_ts: '',
+                    is_live: false,
+                    top_url: ''
                 };
             },
             wombatScript: wombatScript,
@@ -142,6 +144,8 @@ describe('WombatJS', function () {
                         wombat_opts: {},
                         prefix: window.location.origin,
                         wombat_ts: '',
+                        is_live: false,
+                        top_url: ''
                     };
                 },
                 wombatScript: wombatScript,
@@ -179,6 +183,8 @@ describe('WombatJS', function () {
                         wombat_opts: {},
                         prefix: window.location.origin,
                         wombat_ts: '',
+                        is_live: false,
+                        top_url: ''
                     };
                 },
                 wombatScript: wombatScript,
@@ -199,6 +205,8 @@ describe('WombatJS', function () {
                 initScript: function () {
                     wbinfo = {
                         wombat_opts: {},
+                        is_live: false,
+                        top_url: ''
                     };
                 },
                 wombatScript: wombatScript,

--- a/pywb/static/wombatPreservationWorker.js
+++ b/pywb/static/wombatPreservationWorker.js
@@ -1,0 +1,205 @@
+'use strict';
+// thanks wombat
+var STYLE_REGEX = /(url\s*\(\s*[\\"']*)([^)'"]+)([\\"']*\s*\))/gi;
+var IMPORT_REGEX = /(@import\s+[\\"']*)([^)'";]+)([\\"']*\s*;?)/gi;
+var srcsetSplit = /\s*(\S*\s+[\d.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))/;
+// the preserver instance for this worker
+var preserver = null;
+
+function noop() {}
+
+if (typeof self.Promise === 'undefined') {
+    // not kewl we must polyfill Promise
+    self.Promise = function (executor) {
+        executor(noop, noop);
+    };
+    self.Promise.prototype.then = function (cb) {
+        if (cb) cb();
+        return this;
+    };
+    self.Promise.prototype.catch = function () {
+        return this;
+    };
+    self.Promise.all = function (values) {
+        return new Promise(noop);
+    };
+}
+
+if (typeof self.fetch === 'undefined') {
+    // not kewl we must polyfill fetch.
+    self.fetch = function (url) {
+        return new Promise(function (resolve) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url);
+            xhr.send();
+            resolve();
+        });
+    };
+}
+
+self.onmessage = function (event) {
+    var data = event.data;
+    switch (data.type) {
+        case 'values':
+            preserver.preserveMediaSrcset(data);
+            break;
+    }
+};
+
+function pMap(p) {
+    // mapping function to ensure each fetch promises catch has a no op cb
+    return p.catch(noop);
+}
+
+function Preserver(prefix, mod) {
+    if (!(this instanceof Preserver)) {
+        return new Preserver(prefix, mod);
+    }
+    this.prefix = prefix;
+    this.mod = mod;
+    this.prefixMod = prefix + mod;
+    // relative url, WorkerLocation is set by owning document
+    this.relative = prefix.split(location.origin)[1];
+    // schemeless url
+    this.schemeless = '/' + this.relative;
+    // local cache of URLs fetched, to reduce server load
+    this.seen = {};
+    // counter used to know when to clear seen (count > 2500)
+    this.seenCount = 0;
+    // array of promises returned by fetch(URL)
+    this.fetches = [];
+    // array of URL to be fetched
+    this.queue = [];
+    // should we queue a URL or not
+    this.queuing = false;
+    this.urlExtractor = this.urlExtractor.bind(this);
+    this.fetchDone = this.fetchDone.bind(this);
+}
+
+Preserver.prototype.fixupURL = function (url) {
+    // attempt to fix up the url and do our best to ensure we can get dat 200 OK!
+    if (url.indexOf(this.prefixMod) === 0) {
+        return url;
+    }
+    if (url.indexOf(this.relative) === 0) {
+        return url.replace(this.relative, this.prefix);
+    }
+    if (url.indexOf(this.schemeless) === 0) {
+        return url.replace(this.schemeless, this.prefix);
+    }
+    if (url.indexOf(this.prefix) !== 0) {
+        return this.prefix + url;
+    }
+    return url;
+};
+
+Preserver.prototype.safeFetch = function (url) {
+    var fixedURL = this.fixupURL(url);
+    // check to see if we have seen this url before in order
+    // to lessen the load against the server content is preserved from
+    if (this.seen[url] != null) return;
+    this.seen[url] = true;
+    if (this.queuing) {
+        // we are currently waiting for a batch of fetches to complete
+        return this.queue.push(fixedURL);
+    }
+    // queue this urls fetch
+    this.fetches.push(fetch(fixedURL));
+};
+
+Preserver.prototype.urlExtractor = function (match, n1, n2, n3, offset, string) {
+    // Same function as style_replacer in wombat.rewrite_style, n2 is our URL
+    this.safeFetch(n2);
+    return n1 + n2 + n3;
+};
+
+Preserver.prototype.fetchDone = function () {
+    // clear our fetches array in place
+    // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-properties-of-array-instances-length
+    this.fetches.length = 0;
+    // indicate we no longer need to Q
+    this.queuing = false;
+    if (this.queue.length > 0) {
+        // we have a Q of some length drain it
+        this.drainQ();
+    } else if (this.seenCount > 2500) {
+        // we seen 2500 URLs so lets free some memory as at this point
+        // we will probably see some more. GC it!
+        this.seen = {};
+        this.seenCount = 0;
+    }
+};
+
+Preserver.prototype.fetchAll = function () {
+    // if we are queuing or have no fetches this is a no op
+    if (this.queuing) return;
+    if (this.fetches.length === 0) return;
+    // we are about to fetch queue anything that comes our way
+    this.queuing = true;
+    // initiate fetches by turning the initial fetch promises
+    // into rejctionless promises and "await" all
+    Promise.all(this.fetches.map(pMap))
+        .then(this.fetchDone)
+        .catch(this.fetchDone);
+};
+
+Preserver.prototype.drainQ = function () {
+    // clear our Q in place and fill our fetches array
+    while (this.queue.length > 0) {
+        this.fetches.push(fetch(this.queue.shift()));
+    }
+    // fetch all the things
+    this.fetchAll();
+};
+
+Preserver.prototype.extractMedia = function (mediaRules) {
+    // this is a broken down rewrite_style
+    if (mediaRules == null) return;
+    for (var i = 0; i < mediaRules.length; i++) {
+        var rule = mediaRules[i];
+        rule.replace(STYLE_REGEX, this.urlExtractor);
+        rule.replace(IMPORT_REGEX, this.urlExtractor);
+    }
+};
+
+Preserver.prototype.extractSrcset = function (srcsets) {
+    if (srcsets == null || srcsets.values == null) return;
+    var srcsetValues = srcsets.values;
+    // was srcsets from rewrite_srcset and if so no need to split
+    var presplit = srcsets.presplit;
+    for (var i = 0; i < srcsetValues.length; i++) {
+        var srcset = srcsetValues[i];
+        if (presplit) {
+            // was rewrite_srcset so just ensure we just
+            // grab the URL not width/height key
+            this.safeFetch(srcset.split(' ')[0]);
+        } else {
+            // was from extract from local doc so we need to duplicate  work
+            var values = srcset.split(srcsetSplit).filter(Boolean);
+            for (var j = 0; j < values.length; j++) {
+                var value = values[j].trim();
+                if (value.length > 0) {
+                    this.safeFetch(value.split(' ')[0]);
+                }
+            }
+        }
+    }
+};
+
+Preserver.prototype.preserveMediaSrcset = function (data) {
+    // we got a message and now we preserve!
+    // these calls turn into no ops if they have no work
+    this.extractMedia(data.media);
+    this.extractSrcset(data.srcset);
+    this.fetchAll();
+};
+
+// initialize ourselves from the query params :)
+try {
+    var loc = new self.URL(location);
+    preserver = new Preserver(loc.searchParams.get('prefix'), loc.searchParams.get('mod'));
+} catch (e) {
+    // likely we are in an older version of safari
+    var search = decodeURIComponent(location.search.split('?')[1]).split('&');
+    preserver = new Preserver(search[0].substr(search[0].indexOf('=') + 1), search[1].substr(search[1].indexOf('=') + 1));
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->
## Description
<!--- Describe your changes in detail -->
This PR introduces to Pywb via changes to `wombat.js` and the addition of a new static resource `wombatPreservationWorker.js` the ability to preserve 
the set of values contained in the `srcset` attribute and images contained in `CSS media query rules`.

The preservation scheme is split into two parts:
1. `wombat`: Initiating `wombatPreservationWorker` and sending it `srcset` and `media query` values for preservation
2. `wombatPreservationWorker`: The [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) responsible for fetching the resources

### wombat
In order to facilitate this new preservation scheme the changes to wombat are as follows. 

##### Three new internal global variables
1. `WBPreserWorker`: a reference to the preservation worker abstraction used by wombat itself
2. `wbSheetMediaQChecker`: a reference to the `load` event callback for checking the stylesheet introduced by `link[rel='stylesheet']`
3. `wbUsePresWorker`: flag indicating if we should use the preservation worker. 

The first two global variables (`WBPreserWorker` and `wbSheetMediaQChecker`) remain undefined unless the third (`wbUsePresWorker`) is true.
`wbUsePresWorker` is set to true when `window.Worker` is non-null and wombat is operating in live mode or the `wbinfo.top_url` contains `record`.

##### New init function initPreserveWorker and PWorker
The new init function, `initPreserveWorker`, contains wombats interface to the new `wombatPreservationWorker`, that was designed to be cross-frame safe.
The init function only introduces the `PWorker` interface when the `wbUsePresWorker` flag is true.

`initPreserveWorker` operates similar to the existing `web worker` override except that it must come first in order to use non-overridden reference to `window.Worker`
which is used by `PWorker` (preservation worker).

`PWorker` is an ES5 class that provides functionality for cross-frame preservation of `srcset` and `media query` CSS rule preservation. 
Creation of the `PWorker` takes two arguments `prefix` (`wb_abs_prefix`) and `mod` (`wbinfo.mod`).
If wombat is operating in the `__WB_replay_top` browser context, the backing worker is created otherwise it is not re-created.
The URL to the backing worker includes query parameters `prefix` and `mod` which are used by `wombatPreservationWorker` to create itself if we can use `window.URL`
otherwise we must immediately send an `init` message containing those values to the worker.  

The `PWorker` class exposes six functions:
1. `deferredSheetExtraction`: Method for checking a `style` or `link[rel='stylesheet']` elements `sheet` property for media query rules. 
Done in a manner that does not block the UI thread by using `Promise.resolve` (when available) or `setTimeout(cb, 1)`.
Used by the `checkStyle` (value of `wbSheetMediaQChecker`), `rewrite_elem` and `override_html_assign` functions.
Usage in `rewrite_elem` is tied to elements `style` (text contents changed and `sheet != null`) and `link[rel='stylesheet']` (via `link.addEventListener('load',wbSheetMediaQChecker)`).

2. `terminate`: terminate the backing web worker, only terminates worker when in the `__WB_replay_top` browser context.

3.  `postMessage`: send a message to the backing web worker. If wombat is in the `__WB_replay_top` browser context sends message directly 
to worker otherwise forwards msg to `__WB_replay_top` which will then send the msg directly to the backing worker.

4. `preserveSrcset`: method used when sending `srcset` values from `rewrite_srcset`
5. `preserveMedia`: method used when sending `media query` values from `deferredSheetExtraction` 
6. `extractFromLocalDoc`: method to check `document.stylesheets` and `document.querySelectorAll('*[srcset]')` when `notify_top` is called from `init_top_frame_notify`

### wombatPreservationWorker
The new file `wombatPreservationWorker.js` contains the worker code used for preserving `srcset` and `media query` values.
Because it is expected of wombat to operate in a wide range of browsers this file contains minimal polyfills of `Promise` and `fetch` if these symbols are not defined.

This worker expects to receive two messages from wombat: 
1. `init`: when the [WHATWG URL](https://url.spec.whatwg.org/#dom-url) parser is not available to instantiate the Preserver class.
2. `values`: contains values to be preserved.
    
The `Preserver` class (ES5) is responsible for the extraction and preservation of the desired values.
The `Preserver` tracks seen URLs, up to 2500 before resetting, in order to lessen the load against the server(s) requests are made too.
If the `Preserver` has seen a URL no fetch is made otherwise it is added to the seen cache.

The `Preserver` class exposes 9 functions:
1. `fixupURL`: Ensures the URL to be fetched are absolute 
2. `safeFetch`: Initiates a URL fetch or queues the URL to be fetched if we are waiting for a batch of fetches to complete
3. `urlExtractor`: Extracts the URL from sheet text (media query) in a similar manner as `style_replacer`
4. `fetchDone`: When a batch of fetches is done ensures the URL queue is drained and if the `Preserver` has seen 2500 URLs clears the seen count for GC purposes.
5. `fetchAll`: Ensures all fetches complete, `fetchDone` is called and indicates we are to queue URLs until fetches complete. 
If `Preserver` is queuing URLs or no fetches are to be made this is a no op.
6. `drainQ`: Drains the queue by calling `safeFetch` for each queued URL and then calls `fetchAll`
7. `extractMedia`: For each style sheet that contained a media query, extract URLs from it's text and fetch initiate a fetch for it if there was a URL 
8. `extractSrcset`: For each `srcset` value, if the value is from `Pworker.preserveSrcset` only fetch URL otherwise from `Pworker.extractFromLocalDoc` need to extract split full `srcset` attribute value and then fetch each URL contained
9. `preserveMediaSrcset`: Used when the `values` message is received and calls `extractMedia`, `extractSrcset` and `fetchAll`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Ref https://github.com/webrecorder/webrecorder/issues/64

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

