### PR TITLE
Enhance help messages in the command line interface

### DIFF
--- a/pywb/apps/cli.py
+++ b/pywb/apps/cli.py
@@ -29,17 +29,24 @@ def live_rewrite_server(args=None):
 class BaseCli(object):
     def __init__(self, args=None, default_port=8080, desc=''):
         parser = ArgumentParser(description=desc)
-        parser.add_argument('-p', '--port', type=int, default=default_port)
-        parser.add_argument('-b', '--bind', default='0.0.0.0')
-        parser.add_argument('-t', '--threads', type=int, default=4)
-        parser.add_argument('--debug', action='store_true')
-        parser.add_argument('--profile', action='store_true')
-
-        parser.add_argument('--live', action='store_true', help='Add live-web handler at /live')
-        parser.add_argument('--record', action='store_true')
-
-        parser.add_argument('--proxy', help='Enable HTTP/S Proxy on specified collection')
-        parser.add_argument('--proxy-record', action='store_true', help='Enable Proxy Recording into specified collection')
+        parser.add_argument('-p', '--port', type=int, default=default_port,
+                            help='Port to listen on (default %s)' % default_port)
+        parser.add_argument('-b', '--bind', default='0.0.0.0',
+                            help='Address to listen on (default 0.0.0.0)')
+        parser.add_argument('-t', '--threads', type=int, default=4,
+                            help='Number of threads to use (default 4)')
+        parser.add_argument('--debug', action='store_true',
+                            help='Enable debug mode')
+        parser.add_argument('--profile', action='store_true',
+                            help='Enable profile mode')
+        parser.add_argument('--live', action='store_true',
+                            help='Add live-web handler at /live')
+        parser.add_argument('--record', action='store_true',
+                            help='Enable recording from the live web')
+        parser.add_argument('--proxy',
+                            help='Enable HTTP/S proxy on specified collection')
+        parser.add_argument('--proxy-record', action='store_true',
+                            help='Enable proxy recording into specified collection')
 
         self.desc = desc
         self.extra_config = {}
@@ -93,8 +100,10 @@ class BaseCli(object):
 #=============================================================================
 class ReplayCli(BaseCli):
     def _extend_parser(self, parser):
-        parser.add_argument('-a', '--autoindex', action='store_true')
-        parser.add_argument('--auto-interval', type=int, default=30)
+        parser.add_argument('-a', '--autoindex', action='store_true',
+                            help='Enable auto-indexing')
+        parser.add_argument('--auto-interval', type=int, default=30,
+                            help='Auto-indexing interval (default 30 seconds)')
 
         parser.add_argument('--all-coll', help='Set "all" collection')
 


### PR DESCRIPTION
## Description
Added help messages to the `add_argument` method calls in class `BaseCli` where none were present yet. This documents the meaning and default values of the available CLI options.

## Motivation and Context
It took me some time to find out e.g. the meaning and default value of the `--bind` option. Now a user won't have to search the docs or the source code for that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
