### PR TITLE
htmlrewriter: if urls contain non-ascii chars, ensure the url is reen…

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -130,31 +130,31 @@ class BaseContentRewriter(object):
                       head_insert=head_insert_str,
                       url=cdx['url'],
                       defmod=self.replay_mod,
-                      parse_comments=rule.get('parse_comments', False))
+                      parse_comments=rule.get('parse_comments', False),
+                      charset=rwinfo.charset)
 
         return rw
 
     def get_head_insert(self, rwinfo, rule, head_insert_func, cdx):
         head_insert_str = ''
-        charset = rwinfo.charset
 
         # if no charset set, attempt to extract from first 1024
-        if not charset:
+        if not rwinfo.charset:
             first_buff = rwinfo.read_and_keep(1024)
-            charset = self.extract_html_charset(first_buff)
+            rwinfo.charset = self.extract_html_charset(first_buff)
 
         if head_insert_func:
             head_insert_orig = head_insert_func(rule, cdx)
 
-            if charset:
+            if rwinfo.charset:
                 try:
-                    head_insert_str = webencodings.encode(head_insert_orig, charset)
+                    head_insert_str = webencodings.encode(head_insert_orig, rwinfo.charset)
                 except:
                     pass
 
             if not head_insert_str:
-                charset = 'utf-8'
-                head_insert_str = head_insert_orig.encode(charset)
+                rwinfo.charset = 'utf-8'
+                head_insert_str = head_insert_orig.encode(rwinfo.charset)
 
             head_insert_str = head_insert_str.decode('iso-8859-1')
 

--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -115,9 +115,11 @@ class HTMLRewriterMixin(StreamingRewriter):
                  css_rewriter_class=None,
                  url = '',
                  defmod='',
-                 parse_comments=False):
+                 parse_comments=False,
+                 charset='utf-8'):
 
         super(HTMLRewriterMixin, self).__init__(url_rewriter, False)
+        self.charset = charset
         self._wb_parse_context = None
 
         if js_rewriter:
@@ -228,6 +230,15 @@ class HTMLRewriterMixin(StreamingRewriter):
         value = value.strip()
         if not value:
             return ''
+
+        # if url is not ascii, ensure its reencoded in expected charset
+        try:
+            value.encode('ascii')
+        except:
+            try:
+                value = value.encode('iso-8859-1').decode(self.charset)
+            except:
+                pass
 
         unesc_value = self.try_unescape(value)
         rewritten_value = self.url_rewriter.rewrite(unesc_value, mod, force_abs)

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from warcio.warcwriter import BufferWARCWriter, GzippingWrapper
 from warcio.statusandheaders import StatusAndHeaders
 
@@ -99,6 +102,17 @@ class TestContentRewriter(object):
         exp = '<html><body><a href="http://localhost:8080/prefix/201701/http://example.com/"></a></body></html>'
         assert is_rw
         assert ('Content-Type', 'text/html; charset=UTF-8') in headers.headers
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_html_utf_8(self):
+        headers = {'Content-Type': 'text/html; charset=utf-8'}
+        content = u'<html><body><a href="http://éxample.com/tésté"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        exp = '<html><body><a href="http://localhost:8080/prefix/201701/http://%C3%A9xample.com/t%C3%A9st%C3%A9"></a></body></html>'
+        assert is_rw
+        assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
         assert b''.join(gen).decode('utf-8') == exp
 
     def test_rewrite_html_js_mod(self, headers):


### PR DESCRIPTION
## Description
pywb attempts to keep page as is as much as possible. However, when rewriting links, the urls are %-encoded, and thus the correct encoding is needed. Previously, was just using default byte->string encoding (latin-1), which results in unicode urls (IRI) links being rewritten incorrectly. This fix re-encodes the urls as correct charset before rewriting the links.

(An alternative fix may not %-encode links at all, but requires a bit more testing for compatibility)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Fixes href= rewriting issues with IRIs, including on:
http://pelicanbomb.com/events/archives/2011
http://esukhia.org/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
