### PR TITLE
Less aggressive fuzzy matching on mime type.

### DIFF
--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -193,7 +193,8 @@ class FuzzyMatcher(object):
 
         # check mime
         mime = cdx.get('mime')
-        if mime and mime in self.default_filters['mimes']:
+        if mime and mime in self.default_filters['mimes'] and \
+                ext == self.get_ext(cdx.get('url')):  # attempt to be stricter
             return True
 
         match_urlkey = cdx['urlkey']

--- a/pywb/warcserver/index/test/test_fuzzymatcher.py
+++ b/pywb/warcserver/index/test/test_fuzzymatcher.py
@@ -133,6 +133,13 @@ class TestFuzzy(object):
 
         assert list(cdx_iter) == self.get_expected(url=actual_url, filters=filters)
 
+    def test_fuzzy_bar_baz_with_ext(self):
+        url = 'http://example.com/foo/bar.png?abc'
+        actual_url = 'http://example.com/foo/bar'
+        params = self.get_params(url, actual_url)
+        cdx_iter, errs = self.fuzzy(self.source, params)
+        assert list(cdx_iter) == self.get_expected(actual_url)
+
     def test_no_fuzzy_disabled(self):
         url = 'http://example.com/?_=123'
         actual_url = 'http://example.com/'
@@ -190,4 +197,16 @@ class TestFuzzy(object):
         cdx_iter, errs = self.fuzzy(self.source, params)
         assert list(cdx_iter) == []
 
+    def test_no_fuzzy_bar_baz(self):
+        url = 'http://example.com/foo/bar'
+        actual_url = 'http://example.com/foo/bas'
+        params = self.get_params(url, actual_url)
+        cdx_iter, errs = self.fuzzy(self.source, params)
+        assert list(cdx_iter) == []
 
+    def test_fuzzy_no_deep_path_mime_match(self):
+        url = 'http://www.website.co.br/~dinosaurs/t'
+        actual_url = 'http://www.website.co.br/~dinosaurs/t/path2/deep-down/what.swf'
+        params = self.get_params(url, actual_url, mime='application/x-shockwave-flash')
+        cdx_iter, errs = self.fuzzy(self.source, params)
+        assert list(cdx_iter) == []


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
This PR makes changes to the fuzzy matching in prefix mode by adding an additional match criteria to `mime` matches in `FuzzyMatcher.match_general_fuzzy_query`.
When a mime type match is being made also match on extension in order to be less aggressive when matching prefix matches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Fix for https://github.com/webrecorder/pywb/issues/343

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
