### PR TITLE
Facebook timeline fuzzy lookup rule

### DIFF
--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -83,6 +83,9 @@ rules:
         match: '("(?:cursor|cursorindex)":["\d\w]+)'
         find_all: true
 
+    - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/profiletimeline'
+      fuzzy_lookup: 'com,facebook\)/.*[?&](__adt=[^&]+).*[&]data=(?:.*?(?:[&]|(profile_id|pagelet_token)[^,]+))'
+
     - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/'
 
       #fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|query_type[^,]+))'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

Added facebook profile timeline fuzzy lookup rule to rules.yaml
The value of __adt is incremented to indicate position in timeline as shown below and the profile_id or pagelet_token contained in the data param identify the facebook user the timeline data is for


Covers both 
- https://www.facebook.com/ajax/pagelet/generic.php/ProfileTimelineProtilesPagelet
- https://www.facebook.com/ajax/pagelet/generic.php/ProfileTimelineProtilesPaginationPagelet


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

