### PR TITLE
Ensure Pywb replays requests for JSON correctly when the original server who sent it said it was text/html   

### DIFF
--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -617,3 +617,11 @@ http://example.com/video_4.m3u8
 
         assert b''.join(gen).decode('utf-8') == filtered
 
+    def test_json_body_but_mime_html(self):
+        headers = {'Content-Type': 'text/html'}
+        content = '{"foo":"bar", "dash": {"on": "true"}'
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_',
+                                                  url='http://example.com/path/file.json')
+        assert headers.headers == [('Content-Type', 'text/html')]
+        result = b''.join(gen).decode('utf-8')
+        assert result == content


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Add content sniffing to the html check of `_fill_text_type_and_charset` when the url ends with .json

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
The page https://032c.com/fred-turner-silicon-valley-thinks-politics-doesnt-exist, makes a request for some JSON at URL

https://032c.com/fred-turner-silicon-valley-thinks-politics-doesnt-exist.json
but the server sends it over as text/html.

Fixes: https://github.com/webrecorder/webrecorder-bug-reports/issues/1457

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
