### PR TITLE
Add recorder option to filter source collection

### DIFF
--- a/docs/manual/configuring.rst
+++ b/docs/manual/configuring.rst
@@ -334,6 +334,7 @@ The full set of configurable options (with their default settings) is as follows
      rollover_size: 100000000
      rollover_idle_secs: 600
      filename_template: my-warc-{timestamp}-{hostname}-{random}.warc.gz
+     source_filter: live
 
 
 The required ``source_coll`` setting specifies the source collection from which to load content that will be recorded.
@@ -348,6 +349,9 @@ subsequent requests. This allows the WARC size to be more manageable and prevent
 
 The ``filename-template`` specifies the naming convention for WARC files, and allows a timestamp, current hostname, and
 random string to be inserted into the filename.
+
+When using an aggregate collection or sequential fallback collection as the source, recording can be limited to pages
+fetched from certain child collection by specifying ``source_filter`` as an regex matching the name of the sub-collection.
 
 For example, if recording with the above config into a collection called ``my-coll``, the user would access:
 

--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -133,7 +133,9 @@ class FrontEndApp(object):
                                           filename_template=recorder_config.get('filename_template'),
                                           dedup_index=dedup_index)
 
-        self.recorder = RecorderApp(self.RECORD_SERVER % str(self.warcserver_server.port), warc_writer)
+        self.recorder = RecorderApp(self.RECORD_SERVER % str(self.warcserver_server.port), warc_writer,
+                                    accept_colls=recorder_config.get('source_filter'))
+
 
         recorder_server = GeventServer(self.recorder, port=0)
 

--- a/tests/test_record_replay.py
+++ b/tests/test_record_replay.py
@@ -173,19 +173,23 @@ class TestRecordFilter(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
                                      }
                      }
         super(TestRecordFilter, cls).setup_class('config_test_record.yaml', custom_config=rec_custom)
-
-    def test_init_and_rec(self):
         manager(['init', 'test-new'])
+        
+    def test_skip_existing(self):
         dir_name = os.path.join(self.root_dir, '_test_colls', 'test-new', 'archive')
         assert os.path.isdir(dir_name)
         res = self.testapp.get('/fallback/cdx?url=http://example.com/?example=1')
         assert res.text != ''
-        res = self.testapp.get('/fallback/cdx?url=http://httpbin.org/get?A=B')
-        assert res.text == ''
-
+        
         res = self.testapp.get('/test-new/record/mp_/http://example.com/?example=1')
         assert 'Example Domain' in res.text
         assert os.listdir(dir_name) == []
+    
+    def test_record_new(self):
+        dir_name = os.path.join(self.root_dir, '_test_colls', 'test-new', 'archive')
+        assert os.path.isdir(dir_name)
+        res = self.testapp.get('/fallback/cdx?url=http://httpbin.org/get?A=B')
+        assert res.text == ''
 
         res = self.testapp.get('/test-new/record/mp_/http://httpbin.org/get?A=B')
         assert res.json['args']['A'] == 'B'

--- a/tests/test_record_replay.py
+++ b/tests/test_record_replay.py
@@ -1,7 +1,7 @@
 from .base_config_test import BaseConfigTest, fmod, CollsDirMixin
 from pywb.manager.manager import main as manager
 from pywb.manager.autoindex import AutoIndexer
-from pywb.warcserver.test.testutils import to_path, HttpBinLiveTests
+from pywb.warcserver.test.testutils import to_path, HttpBinLiveTests, TEST_WARC_PATH, TEST_CDX_PATH
 
 import os
 import time
@@ -152,5 +152,46 @@ class TestRecordCustomConfig(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
         assert len(names) == 1
         assert names[0].startswith('pywb-rec-test-')
         assert names[0].endswith('.warcgz')
+
+
+# ============================================================================
+class TestRecordFilter(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
+
+    @classmethod
+    def setup_class(cls):
+        rec_custom = {'collections': {'fallback': {'sequence': [
+                        {
+                            'index_paths': os.path.join(TEST_CDX_PATH, 'example.cdxj'),
+                            'archive_paths': TEST_WARC_PATH,
+                            'name': 'example'
+                        },{
+                            'index':'$live',
+                            'name': 'live'
+                        }]}},
+                        'recorder': {'source_coll': 'fallback',
+                                     'source_filter': 'live',
+                                     }
+                     }
+        super(TestRecordFilter, cls).setup_class('config_test_record.yaml', custom_config=rec_custom)
+
+    def test_init_and_rec(self):
+        manager(['init', 'test-new'])
+        dir_name = os.path.join(self.root_dir, '_test_colls', 'test-new', 'archive')
+        assert os.path.isdir(dir_name)
+        res = self.testapp.get('/fallback/cdx?url=http://example.com/?example=1')
+        assert res.text != ''
+        res = self.testapp.get('/fallback/cdx?url=http://httpbin.org/get?A=B')
+        assert res.text == ''
+
+        res = self.testapp.get('/test-new/record/mp_/http://example.com/?example=1')
+        assert 'Example Domain' in res.text
+        assert os.listdir(dir_name) == []
+
+        res = self.testapp.get('/test-new/record/mp_/http://httpbin.org/get?A=B')
+        assert res.json['args']['A'] == 'B'
+        names = os.listdir(dir_name)
+        assert len(names) == 1
+        assert names[0].endswith('.warc.gz')
+
 
 


### PR DESCRIPTION
## Description
When using an aggregate collection or sequential fallback collection as the source, this change allow recording to be limited to pages fetched from certain child collection.

## Motivation and Context
The most probable use case is to limit recording to pages that are fetched from live but not from an existing collection. This can be accomplished by setting up an sequential fallback collection with an existing collection followed by live collection, then setting a recording filter. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
