### PR TITLE
content rewriter: encoding check: if response has Content-Encoding bu…

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -374,7 +374,7 @@ class RewriterApp(object):
 
         urlrewriter.rewrite_opts['ua_string'] = environ.get('HTTP_USER_AGENT')
 
-        result = content_rw(record, urlrewriter, cookie_rewriter, head_insert_func, cdx)
+        result = content_rw(record, urlrewriter, cookie_rewriter, head_insert_func, cdx, environ)
 
         status_headers, gen, is_rw = result
 


### PR DESCRIPTION
## Description
Add check for `Content-Encoding` in ContentRewriter and match it against the `Accept-Encoding` provided in the http request. If current content encoding is not supported, decode the content, if not already being decoded for rewriting.

## Motivation and Context
Primarily added for Brotli content that may be replayed in a browser that does not support Brotli.
If `br` is not present in the `Accept-Encoding` header, the content is decoded for replay.
Tests cover the Brotli case but could also work with any content encoding, eg. decoding `gzip` for old browsers that don't support gzip.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
