### PR TITLE
Support non-root deployment of pywb

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -355,6 +355,9 @@ class FrontEndApp(object):
         try:
             endpoint, args = urls.match()
 
+            # store original script_name (original prefix) before modifications are made
+            environ['pywb.app_prefix'] = environ.get('SCRIPT_NAME')
+
             response = endpoint(environ, **args)
             return response(environ, start_response)
 

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -256,6 +256,8 @@ class RewriterApp(object):
 
         urlkey = canonicalize(wb_url.url)
 
+        environ['pywb.host_prefix'] = host_prefix
+
         if self.use_js_obj_proxy:
             content_rw = self.js_proxy_rw
         else:

--- a/pywb/rewrite/templateview.py
+++ b/pywb/rewrite/templateview.py
@@ -139,7 +139,10 @@ class BaseInsertView(object):
         params = env.get(self.jenv.env_template_params_key)
         if params:
             kwargs.update(params)
+
         kwargs['env'] = env
+        kwargs['static_prefix'] = env.get('pywb.host_prefix', '') + env.get('pywb.app_prefix', '') + '/static'
+
 
         return template.render(**kwargs)
 

--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -1,5 +1,5 @@
 {% if not env.pywb_proxy_magic or config.proxy.use_banner | default(true) %}
 <!-- default banner, create through js -->
-<script src='{{ host_prefix }}/{{ static_path }}/default_banner.js'> </script>
-<link rel='stylesheet' href='{{ host_prefix }}/{{ static_path }}/default_banner.css'/>
+<script src='{{ static_prefix }}/default_banner.js'> </script>
+<link rel='stylesheet' href='{{ static_prefix }}/default_banner.css'/>
 {% endif %}

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -12,7 +12,7 @@ html, body
 }
 
 </style>
-<script src='{{ host_prefix }}/{{ static_path }}/wb_frame.js'> </script>
+<script src='{{ static_prefix }}/wb_frame.js'> </script>
 
 {{ banner_html }}
 

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -23,11 +23,11 @@
   wbinfo.is_live = {{ is_live }};
   wbinfo.coll = "{{ coll }}";
   wbinfo.proxy_magic = "{{ env.pywb_proxy_magic }}";
-  wbinfo.static_prefix = "{{ host_prefix }}/{{ static_path }}/";
+  wbinfo.static_prefix = "{{ static_prefix }}/";
 </script>
 
 {% if not wb_url.is_banner_only %}
-<script src='{{ host_prefix }}/{{ static_path }}/wombat.js'> </script>
+<script src='{{ static_prefix }}/wombat.js'> </script>
 <script>
   wbinfo.wombat_ts = "{{ wombat_ts }}";
   wbinfo.wombat_sec = "{{ wombat_sec }}";
@@ -49,7 +49,7 @@
 {% endif %}
 
 {% if config.enable_flash_video_rewrite %}
-<script src='{{ host_prefix }}/{{ static_path }}/vidrw.js'> </script>
+<script src='{{ static_prefix }}/vidrw.js'> </script>
 {% endif %}
 
 {{ banner_html }}

--- a/pywb/templates/index.html
+++ b/pywb/templates/index.html
@@ -8,7 +8,7 @@ This archive contains the following collections:
 <ul>
 {% for route in routes %}
     <li>
-    <a href="{{ '/' + route }}">{{ '/' + route }}</a>
+    <a href="{{ env['pywb.app_prefix'] + '/' + route }}">{{ '/' + route }}</a>
     {% if all_metadata and all_metadata[route] %}
       ({{ all_metadata[route].title }})
     {% endif %}

--- a/pywb/templates/query.html
+++ b/pywb/templates/query.html
@@ -1,12 +1,12 @@
 <html>
 <head>
 <!-- jquery and bootstrap dependencies query view -->
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/query.css">
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/bootstrap.min.css">
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/font-awesome.min.css">
-<script src="{{ host_prefix }}/{{ static_path }}/js/jquery-latest.min.js"></script>
-<script src="{{ host_prefix }}/{{ static_path }}/js/bootstrap.min.js"></script>
-<script src="{{ host_prefix }}/{{ static_path }}/query.js"></script>
+<link rel="stylesheet" href="{{ static_prefix }}/css/query.css">
+<link rel="stylesheet" href="{{ static_prefix }}/css/bootstrap.min.css">
+<link rel="stylesheet" href="{{ static_prefix }}/css/font-awesome.min.css">
+<script src="{{ static_prefix }}/js/jquery-latest.min.js"></script>
+<script src="{{ static_prefix }}/js/bootstrap.min.js"></script>
+<script src="{{ static_prefix }}/query.js"></script>
 </head>
 <body>
   <h2 class="text-center">pywb Query Results</h2>

--- a/tests/test_prefixed_deploy.py
+++ b/tests/test_prefixed_deploy.py
@@ -1,0 +1,50 @@
+from .base_config_test import BaseConfigTest, fmod
+
+
+# ============================================================================
+class TestPrefixedDeploy(BaseConfigTest):
+    @classmethod
+    def setup_class(cls):
+        super(TestPrefixedDeploy, cls).setup_class('config_test.yaml')
+
+    def get(self, url, fmod=''):
+        return super(TestPrefixedDeploy, self).get(url, fmod,
+                        extra_environ={'SCRIPT_NAME': '/prefix',
+                                       'REQUEST_URI': 'http://localhost:80/prefix' + url})
+
+    def test_home(self):
+        resp = self.get('/prefix/')
+        print(resp.text)
+        self._assert_basic_html(resp)
+        assert '/prefix/pywb' in resp.text
+
+    def test_pywb_root(self):
+        resp = self.get('/prefix/pywb/')
+        self._assert_basic_html(resp)
+        assert 'Search' in resp.text
+
+    def test_calendar_query(self):
+        resp = self.get('/prefix/pywb/*/iana.org')
+        self._assert_basic_html(resp)
+
+        assert '/prefix/static/query.js' in resp.text
+
+    def test_replay_content(self, fmod):
+        resp = self.get('/prefix/pywb/20140127171238{0}/http://www.iana.org/', fmod)
+        self._assert_basic_html(resp)
+
+        assert '"20140127171238"' in resp.text, resp.text
+        assert "'http://localhost:80/prefix/static/wombat.js'" in resp.text
+        assert "'http://localhost:80/prefix/static/default_banner.js'" in resp.text
+        assert '"http://localhost:80/prefix/static/"' in resp.text
+        assert '"http://localhost:80/prefix/pywb/"' in resp.text
+        assert 'new _WBWombat' in resp.text, resp.text
+        assert '"/prefix/pywb/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text, resp.text
+
+    def test_static_content(self):
+        resp = self.get('/prefix/static/default_banner.css')
+        assert resp.status_int == 200
+        assert resp.content_type == 'text/css'
+        assert resp.content_length > 0
+
+


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
Supports deploying pywb under a prefix on the web server, usually provided via WSGI `SCRIPT_NAME` field.

For example, deploying under `/prefix`, all collections would be accessed via
`/prefix/<coll name>/` and all static paths would be `/prefix/static/...`
Updates various jinja templates to use  `{{ static_prefix }}` to specify the correct static path.

(The `SCRIPT_NAME` field is modified internally as part of collection path lookup, so
saving original 'script name' in `pywb.app_prefix` WSGI env var).

## Motivation and Context
Have several use cases, including UK Web Archive, Scalar prototype where pywb needs to be deployed under a prefix and not as root webapp.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
