### PR TITLE
add sample Apache configuration

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -189,3 +189,28 @@ See the `Nginx Docs <https://nginx.org/en/docs/>`_ for a lot more details on how
         }
     }
 
+Sample Apache Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following Apache configuration snippet can be used to deploy pywb *without* uwsgi. A configuration with uwsgi is also probably possible but this covers the simplest case of launching the `wayback` binary directly.
+
+The configuration assumes pywb is running on port 8080 on localhost, but it could be on a different machine as well. The configuration can be updated to use HTTPS (as below), but the `force_scheme: https` option needs to be added to the `config.yml` file.
+
+.. code:: apache
+
+    <VirtualHost *:80>
+         ServerName proxy.example.com
+         Redirect / https://proxy.example.com/
+         DocumentRoot /var/www/html/
+    </VirtualHost>
+
+    <VirtualHost *:443>
+         ServerName proxy.example.com
+         SSLEngine on
+         DocumentRoot /var/www/html/
+         ErrorDocument 404 /404.html
+         ProxyPreserveHost On
+         ProxyPass /.well-known/ !
+         ProxyPass / http://localhost:8080/
+         ProxyPassReverse / http://localhost:8080/
+    </VirtualHost>

--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -194,7 +194,7 @@ Sample Apache Configuration
 
 The following Apache configuration snippet can be used to deploy pywb *without* uwsgi. A configuration with uwsgi is also probably possible but this covers the simplest case of launching the `wayback` binary directly.
 
-The configuration assumes pywb is running on port 8080 on localhost, but it could be on a different machine as well. The configuration can be updated to use HTTPS (as below), but the `force_scheme: https` option needs to be added to the `config.yml` file.
+The configuration assumes pywb is running on port 8080 on localhost, but it could be on a different machine as well.
 
 .. code:: apache
 
@@ -213,4 +213,5 @@ The configuration assumes pywb is running on port 8080 on localhost, but it coul
          ProxyPass /.well-known/ !
          ProxyPass / http://localhost:8080/
          ProxyPassReverse / http://localhost:8080/
+         RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
     </VirtualHost>


### PR DESCRIPTION
## Description

This patch updates the documentation to add a configuration snippet
for Apache.

## Motivation and Context

This configuration can be used when launching `wayback` in the default
configuration, which is useful to add stuff like access control,
authentication, or encryption without going through the trouble of
setting up a UWSGI proxy.

The `force_scheme` configuration wouldn't be necessary if pywb would
support the (de-facto) standard `X-Forwarded-Proto` header. This is
not, unfortunately, currently the case so the configuration cannot be
only on Apache's side. Note that this is similar to the concerns raised in #314

## Types of changes

- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
