### PR TITLE
rules: add fuzzy matching rule for vimeo, canonicalizing out a timest…

### DIFF
--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -322,6 +322,11 @@ rules:
           - videoFileId
           - signature
 
+    - url_prefix: 'net,akamaized,gcs-vimeo)/'
+
+      fuzzy_lookup:
+        match: '([/\d]+\.mp4)$'
+        replace: '.net/'
 
     # vine
     #=================================================================


### PR DESCRIPTION
## Description

Additional fuzzy matching rule for vimeo videos, canonicalizing the variable hmac/timestamp portion of url.