### PR TITLE
Encoding Fix

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -231,10 +231,12 @@ class HTMLRewriterMixin(StreamingRewriter):
         if not value:
             return ''
 
-        # if url is not ascii, ensure its reencoded in expected charset
-        try:
-            value.encode('ascii')
-        except:
+
+        orig_value = value
+
+        # if not utf-8, then stream was encoded as iso-8859-1, and need to reencode
+        # into correct charset
+        if self.charset != 'utf-8' and self.charset != 'iso-8859-1':
             try:
                 value = value.encode('iso-8859-1').decode(self.charset)
             except:
@@ -242,6 +244,10 @@ class HTMLRewriterMixin(StreamingRewriter):
 
         unesc_value = self.try_unescape(value)
         rewritten_value = self.url_rewriter.rewrite(unesc_value, mod, force_abs)
+
+        # if no rewriting has occured, ensure we return original, not reencoded value
+        if rewritten_value == value:
+            return orig_value
 
         if unesc_value != value and rewritten_value != unesc_value:
             rewritten_value = rewritten_value.replace(unesc_value, value)

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -110,6 +110,17 @@ class TestContentRewriter(object):
         assert ('Content-Type', 'text/html; charset=UTF-8') in headers.headers
         assert b''.join(gen).decode('utf-8') == exp
 
+    def test_rewrite_text_utf_8_long(self):
+        headers = {'Content-Type': 'text/html; charset=utf-8'}
+        exp = u'éeé' * 3277
+        content = exp.encode('utf-8')
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        assert is_rw
+        assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
+        assert b''.join(gen).decode('utf-8') == exp
+
     def test_rewrite_html_utf_8(self):
         headers = {'Content-Type': 'text/html; charset=utf-8'}
         content = u'<html><body><a href="http://éxample.com/tésté"></a></body></html>'

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -121,6 +121,39 @@ class TestContentRewriter(object):
         assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
         assert b''.join(gen).decode('utf-8') == exp
 
+    def test_rewrite_html_utf_8_anchor(self):
+        headers = {'Content-Type': 'text/html; charset=utf-8'}
+        content = u'<html><body><a href="#éxample-tésté"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        exp = u'<html><body><a href="#éxample-tésté"></a></body></html>'
+        assert is_rw
+        assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_html_other_encoding(self):
+        headers = {'Content-Type': 'text/html; charset=latin-1'}
+        content = b'<html><body><a href="http://\xe9xample.com/t\xe9st\xe9"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        exp = '<html><body><a href="http://localhost:8080/prefix/201701/http://%C3%A9xample.com/t%C3%A9st%C3%A9"></a></body></html>'
+        assert is_rw
+        assert ('Content-Type', 'text/html; charset=latin-1') in headers.headers
+        assert b''.join(gen).decode('latin-1') == exp
+
+    def test_rewrite_html_other_encoding_anchor(self):
+        headers = {'Content-Type': 'text/html; charset=latin-1'}
+        content = b'<html><body><a href="#\xe9xample-t\xe9st\xe9"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        exp = u'<html><body><a href="#éxample-tésté"></a></body></html>'
+        assert is_rw
+        assert ('Content-Type', 'text/html; charset=latin-1') in headers.headers
+        assert b''.join(gen).decode('latin-1') == exp
+
     def test_rewrite_html_js_mod(self, headers):
         content = '<html><body><a href="http://example.com/"></a></body></html>'
 


### PR DESCRIPTION
## Description
Additional fixes from bug introduced in #361, which could cause urls to be reencoded with the wrong encoding. The assumption was that all unicode urls will be %-encoded. However, if a url is not rewritten, such as an anchor, it would not be %-encoded.

Now checking if rewritten url is the same, and then returning the original value.

Also, optimizing for utf-8: if content known to be utf-8, use that encoding for decoding the stream for rewriting. Otherwise, default to decoding as latin-1 (ignore encoding), and re-encode only the urls as utf-8.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
