### PR TITLE
encoding fix: additional fix to #376 for banner encoding:

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -153,9 +153,9 @@ class BaseContentRewriter(object):
                 except:
                     pass
 
+            # no charset detected, encode banner as ascii html entities
             if not head_insert_str:
-                rwinfo.charset = 'utf-8'
-                head_insert_str = head_insert_orig.encode(rwinfo.charset)
+                head_insert_str = head_insert_orig.encode('ascii', 'xmlcharrefreplace')
 
             head_insert_str = head_insert_str.decode('iso-8859-1')
 


### PR DESCRIPTION
- if no encoding is detected, don't default to utf-8
- if no encoding known, encode banner as 'ascii' with 'xmlcharrefreplace', converting to xml entities
- tests: add tests for rewriting with no known encoding