### PR TITLE
Ensure that Preservation workers deferredSheetExtraction is guarded against null CSSRuleList

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1352,9 +1352,10 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 }
             }
 
-            PWorker.prototype.deferredSheetExtraction = function(rules) {
+            PWorker.prototype.deferredSheetExtraction = function(sheet) {
+                var rules = sheet.cssRules || sheet.rules;
                 // if no rules this a no op
-                if (rules.length === 0) return;
+                if (!rules || rules.length === 0) return;
                 function extract() {
                     // loop through each rule of the stylesheet
                     var media = [];
@@ -1450,7 +1451,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             // check no op condition
             if (this.sheet == null) return;
             // defer extraction to be nice :)
-            WBPreserWorker.deferredSheetExtraction(this.sheet.cssRules);
+            WBPreserWorker.deferredSheetExtraction(this.sheet);
         };
     }
 
@@ -1758,7 +1759,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                     if (wbUsePresWorker && elem.sheet != null) {
                         // we have a stylesheet so lets be nice to UI thread
                         // and defer extraction
-                        WBPreserWorker.deferredSheetExtraction(elem.sheet.cssRules);
+                        WBPreserWorker.deferredSheetExtraction(elem.sheet);
                     }
                 }
                 break;
@@ -2195,7 +2196,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             orig_setter.call(this, res);
             if (wbUsePresWorker && this.tagName === 'STYLE' && this.sheet != null) {
                 // got preserve all the things
-                WBPreserWorker.deferredSheetExtraction(this.sheet.rules);
+                WBPreserWorker.deferredSheetExtraction(this.sheet);
             }
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Added check for rules to be null to the noop case in  deferredSheetExtraction (edge case)
Ensures that the CSS rule extraction from style tags checks both probably properties that the CSSRuleList can be on (cssRules or rules)

See https://www.youtube.com/ in FF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
