### PR TITLE
wrong encoding fallback: don't rely on content-type charset=utf-8 as …

### DIFF
--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -295,6 +295,26 @@ class TestContentRewriter(object):
 
         assert is_rw == False
 
+    def test_binary_wrong_content_type_html(self):
+        headers = {'Content-Type': 'text/html; charset=utf-8'}
+        content = b'\xe9\x11\x12\x13\x14'
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
+
+        assert is_rw == True
+        assert b''.join(gen) == content
+
+    def test_binary_wrong_content_type_css(self):
+        headers = {'Content-Type': 'text/css; charset=utf-8'}
+        content = b'\xe9\x11\x12\x13\x14'
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701cs_')
+
+        assert ('Content-Type', 'text/css; charset=utf-8') in headers.headers
+
+        assert is_rw == True
+        assert b''.join(gen) == content
+
     def test_binary_dechunk(self):
         headers = {'Content-Type': 'application/octet-stream',
                    'Transfer-Encoding': 'chunked'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
Handle if content-type incorrectly has charset="utf-8".
Only use utf-8 encoding if parsing HTML, otherwise use the default latin-1 as before.
If parsing HTML and utf-8 encoding fails, use latin-1 for remainder (which often will be the entire stream).
Supports the case (added test cases) where binary files are served with wrong content-type, eg.
`Content-Type: text/html; charset="utf-8"` or `Content-Type: text/css; charset="utf-8"` is returned for a binary font.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
