### PR TITLE
wombat reinit fix

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2253,6 +2253,12 @@ var _WBWombat = function($wbwindow, wbinfo) {
     //============================================
     function override_frames_access($wbwindow)
     {
+        // If $wbwindow.frames is the window itself, nothing to override
+        // This can be handled in the Obj Proxy
+        if ($wbwindow.Proxy && $wbwindow === $wbwindow.frames) {
+            return;
+        }
+
         $wbwindow.__wb_frames = $wbwindow.frames;
 
         var getter = function() {
@@ -3543,6 +3549,9 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 }
             }
         } else if (type === "object" && retVal && retVal._WB_wombat_obj_proxy) {
+            if (retVal instanceof Window) {
+                init_new_window_wombat(retVal);
+            }
             return retVal._WB_wombat_obj_proxy;
         }
 

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -4091,3 +4091,13 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
 window._WBWombat = _WBWombat;
 
+window._WBWombatInit = function() {
+  if (!this._wb_wombat || !this._wb_wombat.actual) {
+    this._wb_wombat = new _WBWombat(this, wbinfo);
+    this._wb_wombat.actual = true;
+  } else if (!this._wb_wombat) {
+    console.warn("_wb_wombat missing!");
+  }
+}
+
+

--- a/pywb/static/wombatProxyMode.js
+++ b/pywb/static/wombatProxyMode.js
@@ -374,3 +374,14 @@ var _WBWombat = function ($wbwindow, wbinfo) {
 
 window._WBWombat = _WBWombat;
 
+window._WBWombatInit = function() {
+  if (!this._wb_wombat || !this._wb_wombat.actual) {
+    this._wb_wombat = new _WBWombat(this, wbinfo);
+    this._wb_wombat.actual = true;
+  } else if (!this._wb_wombat) {
+    console.warn("_wb_wombat missing!");
+  }
+}
+
+
+

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -44,10 +44,8 @@
 
   wbinfo.wombat_opts = {};
 
-  if (window && window._WBWombat && !window._wb_wombat) {
-    window._wb_wombat = new _WBWombat(window, wbinfo);
-  } else if (!window._wb_wombat) {
-    console.warn("_wb_wombat missing!");
+  if (window && window._WBWombatInit) {
+    window._WBWombatInit();
   }
 </script>
 {% else %}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,7 +101,7 @@ class TestWbIntegration(BaseConfigTest):
 
         assert '"20140127171238"' in resp.text, resp.text
         assert 'wombat.js' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert '_WBWombatInit' in resp.text, resp.text
         assert '/pywb/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text
 
         if fmod == 'mp_':

--- a/tests/test_memento.py
+++ b/tests/test_memento.py
@@ -73,7 +73,7 @@ class TestMemento(MementoMixin, BaseConfigTest):
         # Body
         assert '"20140127171238"' in resp.text
         assert 'wombat.js' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert 'WBWombatInit' in resp.text, resp.text
         assert '/pywb/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text
 
     def test_memento_at_timegate_latest(self, fmod):

--- a/tests/test_prefixed_deploy.py
+++ b/tests/test_prefixed_deploy.py
@@ -38,7 +38,7 @@ class TestPrefixedDeploy(BaseConfigTest):
         assert "'http://localhost:80/prefix/static/default_banner.js'" in resp.text
         assert '"http://localhost:80/prefix/static/"' in resp.text
         assert '"http://localhost:80/prefix/pywb/"' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert 'WBWombatInit' in resp.text, resp.text
         assert '"/prefix/pywb/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text, resp.text
 
     def test_static_content(self):

--- a/tests/test_redirect_classic.py
+++ b/tests/test_redirect_classic.py
@@ -19,7 +19,7 @@ class TestRedirectClassic(BaseConfigTest):
 
         assert '"20140127171238"' in resp.text, resp.text
         assert 'wombat.js' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert 'WBWombatInit' in resp.text, resp.text
         assert '/pywb/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text
 
         assert ('wbinfo.is_framed = ' + ('true' if fmod else 'false')) in resp.text

--- a/tests/test_root_coll.py
+++ b/tests/test_root_coll.py
@@ -13,7 +13,7 @@ class TestRootColl(BaseConfigTest):
         # Body
         assert '"20140127171238"' in resp.text
         assert 'wombat.js' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert 'WBWombatInit' in resp.text, resp.text
         assert '/20140127171238{0}/http://www.iana.org/time-zones"'.format(fmod) in resp.text
 
     def test_root_replay_no_ts(self, fmod):
@@ -23,7 +23,7 @@ class TestRootColl(BaseConfigTest):
         # Body
         assert 'request_ts = ""' in resp.text
         assert 'wombat.js' in resp.text
-        assert 'new _WBWombat' in resp.text, resp.text
+        assert 'WBWombatInit' in resp.text, resp.text
         assert '/{0}http://www.iana.org/time-zones"'.format(fmod_slash) in resp.text
 
     def test_root_replay_redir(self, fmod):


### PR DESCRIPTION
## Motivation and Context
In PR #339, removed the reinit of wombat that was caused by document import.
However, wombat reinit was originally added if the original init was 'synthetic' (from a call to init_new_window_wombat()) and needed to be reinited when the actual iframe content loads (e0878f0f670dfbe1f24ba0745a5b4b2fd2c85ac2)
This now always happens since the `frames` object wrapper inits all the iframes with init_new_window_wombat() 

This change allows the reinit of synthetic wombat, but not actual wombat loaded with the page.
A new flag `_wb_wombat.actual` is added in the init function.

The init logic has now also been moved to `_WBWombatInit` function in wombat.js and wombatProxyMode.js to avoid duplicating the logic in custom head inserts.

Also includes an optimization for `window.frames`. Since `window.frames === window` in modern browsers, no custom override is needed! (Retain existing one for backwards compatibility).

For window Proxy wrapper, if returning another window (eg. from frames), simply call init_new_window_wombat() on demand, instead of initing wombat on all present frames on startup.

Fixes replay for: http://www.wendyluck.com/music/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
