### PR TITLE
Rewriting fixes for http-only cookies, bad content-length, and document with base

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -175,6 +175,12 @@ class RewriterApp(object):
 
         content_length = (record.http_headers.
                           get_header('Content-Length'))
+
+        if content_length is None:
+            return
+
+        content_length = content_length.split(',')[0]
+
         try:
             content_length = int(content_length)
             if not range_end:

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -251,8 +251,8 @@ var _WBWombat = function($wbwindow, wbinfo) {
     //============================================
     var rewrite_url = rewrite_url_;
 
-    function rewrite_url_debug(url, use_rel, mod) {
-        var rewritten = rewrite_url_(url, use_rel, mod);
+    function rewrite_url_debug(url, use_rel, mod, doc) {
+        var rewritten = rewrite_url_(url, use_rel, mod, doc);
         if (url != rewritten) {
             console.log('REWRITE: ' + url + ' -> ' + rewritten);
         } else {
@@ -280,7 +280,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
 
     //============================================
-    function rewrite_url_(url, use_rel, mod) {
+    function rewrite_url_(url, use_rel, mod, doc) {
         // If undefined, just return it
         if (!url) {
             return url;
@@ -369,7 +369,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
         // Use a parser
         if (url.charAt(0) == ".") {
-            url = resolve_rel_url(url);
+            url = resolve_rel_url(url, doc);
         }
 
         // If full url starting with http://, https:// or //
@@ -1606,7 +1606,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
                 return;
             }
             var mod = rwModForElement(elem, name);
-            new_value = rewrite_url(value, false, mod);
+            new_value = rewrite_url(value, false, mod, elem.ownerDocument);
         }
 
         if (new_value != value) {

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -108,7 +108,7 @@ class BaseLoader(object):
         # Try to set content-length, if it is available and valid
         try:
             content_len = int(content_len_str)
-        except (KeyError, TypeError):
+        except (ValueError, TypeError):
             content_len = -1
 
         if content_len >= 0:

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -1,6 +1,7 @@
 from .base_config_test import BaseConfigTest, fmod_sl
 from pywb.warcserver.test.testutils import HttpBinLiveTests
 import pytest
+import sys
 
 
 # ============================================================================
@@ -37,6 +38,7 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
         resp = self.head('/live/{0}httpbin.org/get?foo=bar', fmod_sl)
         assert resp.status_int == 200
 
+    @pytest.mark.skipif(sys.version_info < (3,0), reason='does not respond in 2.7')
     def test_live_bad_content_length(self, fmod_sl):
         resp = self.get('/live/{0}httpbin.org/response-headers?content-length=149,149', fmod_sl, status=200)
         assert resp.headers['Content-Length'] == '149'
@@ -44,6 +46,7 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
         resp = self.get('/live/{0}httpbin.org/response-headers?Content-Length=xyz', fmod_sl, status=200)
         assert resp.headers['Content-Length'] == '90'
 
+    @pytest.mark.skipif(sys.version_info < (3,0), reason='does not respond in 2.7')
     def test_live_bad_content_length_with_range(self, fmod_sl):
         resp = self.get('/live/{0}httpbin.org/response-headers?content-length=149,149', fmod_sl,
                         headers={'Range': 'bytes=0-'}, status=206)

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -37,6 +37,24 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
         resp = self.head('/live/{0}httpbin.org/get?foo=bar', fmod_sl)
         assert resp.status_int == 200
 
+    def test_live_bad_content_length(self, fmod_sl):
+        resp = self.get('/live/{0}httpbin.org/response-headers?content-length=149,149', fmod_sl, status=200)
+        assert resp.headers['Content-Length'] == '149'
+
+        resp = self.get('/live/{0}httpbin.org/response-headers?Content-Length=xyz', fmod_sl, status=200)
+        assert resp.headers['Content-Length'] == '90'
+
+    def test_live_bad_content_length_with_range(self, fmod_sl):
+        resp = self.get('/live/{0}httpbin.org/response-headers?content-length=149,149', fmod_sl,
+                        headers={'Range': 'bytes=0-'}, status=206)
+        assert resp.headers['Content-Length'] == '149'
+        assert resp.headers['Content-Range'] == 'bytes 0-148/149'
+
+        resp = self.get('/live/{0}httpbin.org/response-headers?Content-Length=xyz', fmod_sl,
+                        headers={'Range': 'bytes=0-'}, status=206)
+        assert resp.headers['Content-Length'] == '90'
+        assert resp.headers['Content-Range'] == 'bytes 0-89/90'
+
     def test_live_live_frame(self):
         resp = self.testapp.get('/live/http://example.com/')
         assert resp.status_int == 200


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Motivation and Context
This includes three rewriting fixes:

1) (Server-Side) Add cookies for all modifiers: when rewriting http-only cookies that have a path ending in `/` and 
added to an `mp_/` or `if_/` modifier, also add the cookie for all other common modifiers (`im_`, `js_`, `cs_`, `oe_`), as this cookie is likely a session cookie and other resources loaded with those modifiers may need the cookie as well. This solves the general issue of a cookie set on an `mp_` page not being accessible to css/js/other embeds. (Server-Side) 

2) If Content-Length header is of the form `Content-Length: num, num`, just use the first number. Occasionally seen if content-length is added twice somehow. (Server-Side)

3) Better relative url rewriting: When rewriting urls from `rewrite_elem()`, pass the element document to `rewrite_url` so that path-relative `../path` and `./path` urls can be resolved from the `baseURI` of the `ownerDocument` of that element, not of the page. Useful when rewriting iframe content, separate documents.

Pages fixed:
1) and 3) fixes replay of https://www.fulcrum.org/epubs/4t64gn875?locale=en#/6/2[Cover]!/4/1:0
2) fixes audio download on http://www.wendyluck.com/music/


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
