### PR TITLE
Support X-Forwarded-Proto header to specify scheme

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -103,6 +103,7 @@ class RewriterApp(object):
         else:
             self.csp_header = None
 
+        # deprecated: Use X-Forwarded-Proto header instead!
         self.force_scheme = config.get('force_scheme')
 
     def add_csp_header(self, wb_url, status_headers):
@@ -223,8 +224,10 @@ class RewriterApp(object):
         wb_url = wb_url.replace('#', '%23')
         wb_url = WbUrl(wb_url)
 
-        if self.force_scheme:
-            environ['wsgi.url_scheme'] = self.force_scheme
+        proto = environ.get('HTTP_X_FORWARDED_PROTO', self.force_scheme)
+
+        if proto:
+            environ['wsgi.url_scheme'] = proto
 
         is_timegate = self._check_accept_dt(wb_url, environ)
 

--- a/tests/test_force_https.py
+++ b/tests/test_force_https.py
@@ -5,8 +5,21 @@ from .base_config_test import BaseConfigTest, fmod
 class TestForceHttps(BaseConfigTest):
     @classmethod
     def setup_class(cls):
-        super(TestForceHttps, cls).setup_class('config_test.yaml',
-                                               custom_config={'force_scheme': 'https'})
+        super(TestForceHttps, cls).setup_class('config_test.yaml')
+
+    def test_force_https_replay_1(self, fmod):
+        resp = self.get('/pywb/20140128051539{0}/http://example.com/', fmod,
+                        headers={'X-Forwarded-Proto': 'https'})
+
+        assert '"https://localhost:80/pywb/20140128051539{0}/http://www.iana.org/domains/example"'.format(fmod) in resp.text, resp.text
+
+
+# ============================================================================
+class TestForceHttpsConfig(BaseConfigTest):
+    @classmethod
+    def setup_class(cls):
+        super(TestForceHttpsConfig, cls).setup_class('config_test.yaml',
+                                                     custom_config={'force_scheme': 'https'})
 
     def test_force_https_replay_1(self, fmod):
         resp = self.get('/pywb/20140128051539{0}/http://example.com/', fmod)
@@ -18,11 +31,11 @@ class TestForceHttps(BaseConfigTest):
 class TestForceHttpsRedirect(BaseConfigTest):
     @classmethod
     def setup_class(cls):
-        super(TestForceHttpsRedirect, cls).setup_class('config_test_redirect_classic.yaml',
-                                                       custom_config={'force_scheme': 'https'})
+        super(TestForceHttpsRedirect, cls).setup_class('config_test_redirect_classic.yaml')
 
     def test_force_https_redirect_replay_1(self, fmod):
-        resp = self.get('/pywb/20140128051539{0}/http://example.com/', fmod)
+        resp = self.get('/pywb/20140128051539{0}/http://example.com/', fmod,
+                        headers={'X-Forwarded-Proto': 'https'})
 
         assert resp.headers['Location'] == 'https://localhost:80/pywb/20140127171251{0}/http://example.com'.format(fmod)
         resp = resp.follow()
@@ -37,11 +50,11 @@ class TestForceHttpsRedirect(BaseConfigTest):
 class TestForceHttpsRoot(BaseConfigTest):
     @classmethod
     def setup_class(cls):
-        super(TestForceHttpsRoot, cls).setup_class('config_test_root_coll.yaml',
-                                                   custom_config={'force_scheme': 'https'})
+        super(TestForceHttpsRoot, cls).setup_class('config_test_root_coll.yaml')
 
     def test_force_https_root_replay_1(self, fmod):
-        resp = self.get('/20140128051539{0}/http://www.iana.org/domains/example', fmod)
+        resp = self.get('/20140128051539{0}/http://www.iana.org/domains/example', fmod,
+                        headers={'X-Forwarded-Proto': 'https'})
 
         assert resp.headers['Location'] == 'https://localhost:80/20140128051539{0}/https://www.iana.org/domains/reserved'.format(fmod)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->
If the `X-Forwarded-Proto` header is set, override the existing scheme (specified via WSGI `wsgi.url_scheme`) with the value of the header.

## Description
<!--- Describe your changes in detail -->
As raised in #374, use this header instead of `force_scheme` config to allow specifying the scheme for url rewriting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
When running behind a reverse proxy, it is necessary to dynamically specify the scheme.
This allows more flexibility in specifying the scheme and avoiding the fixed config setting.
The `force_scheme` config is being deprecated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
