### PR TITLE
live rewriting/utf-8 headers: fix for sites that have utf-8 in header…

### DIFF
--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -353,6 +353,17 @@ class LiveWebLoader(BaseLoader):
                     v = self.unrewrite_header(cdx, v)
 
                 http_headers_buff += n + ': ' + v + '\r\n'
+
+            http_headers_buff += '\r\n'
+
+            try:
+                # http headers could be encoded as utf-8 (though non-standard)
+                # first try utf-8 encoding
+                http_headers_buff = http_headers_buff.encode('utf-8')
+            except:
+                # then, fall back to latin-1
+                http_headers_buff = http_headers_buff.encode('latin-1')
+
         except:  #pragma: no cover
         #PY 2
             resp_headers = orig_resp.msg.headers
@@ -374,8 +385,8 @@ class LiveWebLoader(BaseLoader):
                 else:
                     http_headers_buff += line
 
-        http_headers_buff += '\r\n'
-        http_headers_buff = http_headers_buff.encode('latin-1')
+            # if python2, already byte headers, so leave as is
+            http_headers_buff += '\r\n'
 
         try:
             fp = upstream_res._fp.fp

--- a/tests/base_config_test.py
+++ b/tests/base_config_test.py
@@ -22,11 +22,13 @@ def fmod_sl(request):
 
 # ============================================================================
 class BaseConfigTest(BaseTestClass):
+    lint_app = True
+
     @classmethod
     def get_test_app(cls, config_file, custom_config=None):
         config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), config_file)
         app = FrontEndApp(config_file=config_file, custom_config=custom_config)
-        return app, webtest.TestApp(app)
+        return app, webtest.TestApp(app, lint=cls.lint_app)
 
     @classmethod
     def setup_class(cls, config_file, include_non_frame=True, custom_config=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
When loading from live web, some sites serve http header encoded as UTF-8, which is not standard for HTTP/1.x but is allowed in HTTP/2.

Currently, pywb attempts to treat the headers as latin-1, instead attempt to encode as utf-8 first, only then as latin-1. In Python 2, since already have the raw bytestrings for headers, don't do any encoding.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
https://wordpress.org/ includes a utf-8 header rendering the page non-browsable via pywb.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
