### PR TITLE
Server-Side Rewrite: 'location' rewrite fix to avoid rewriting '$location'

### DIFF
--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -93,7 +93,7 @@ if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
 
         rules = [
            (r'(?<=\.)postMessage\b\(', self.add_prefix('__WB_pmw(self).'), 0),
-           (r'(?<!\.)\blocation\b\s*[=]\s*(?![=])', self.add_suffix(check_loc), 0),
+           (r'(?<![$.])\s*location\b\s*[=]\s*(?![=])', self.add_suffix(check_loc), 0),
            (r'\breturn\s+this\b\s*(?![.$])', self.replace_str(this_rw), 0),
            (r'(?<=[\n])\s*this\b(?=(?:\.(?:{0})\b))'.format(prop_str), self.replace_str(';' + this_rw), 0),
            (r'(?<![$.])\s*this\b(?=(?:\.(?:{0})\b))'.format(prop_str), self.replace_str(this_rw), 0),

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -194,6 +194,19 @@ r"""
 >>> _test_js_obj_proxy('return this.foo')
 'return this.foo'
 
+>>> _test_js_obj_proxy(r'this.$location = http://example.com/')
+'this.$location = http://example.com/'
+
+>>> _test_js_obj_proxy(r'this.  $location = http://example.com/')
+'this.  $location = http://example.com/'
+
+>>> _test_js_obj_proxy(r'this. _location = http://example.com/')
+'this. _location = http://example.com/'
+
+>>> _test_js_obj_proxy(r'this. alocation = http://example.com/')
+'this. alocation = http://example.com/'
+
+
 
 #=================================================================
 # XML Rewriting

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -206,6 +206,9 @@ r"""
 >>> _test_js_obj_proxy(r'this. alocation = http://example.com/')
 'this. alocation = http://example.com/'
 
+>>> _test_js_obj_proxy(r'this. location = http://example.com/')
+'this. location = (self.__WB_check_loc && self.__WB_check_loc(location) || {}).href = http://example.com/'
+
 
 
 #=================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Minor changes to regex to ensure `this.$location` is not treated same as `this.location`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
`$location` was being rewritten incorrectly.

Fixes replay on React/Angular sites which use $location
Example: https://www.tajalindley.com/shop

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
