### PR TITLE
Use actual page scheme instead of defaulting to http when extracting original url

### DIFF
--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -142,6 +142,7 @@ describe('WombatJS', function () {
                 initScript: function () {
                     wbinfo = {
                         wombat_opts: {},
+                        wombat_scheme: 'http',
                         prefix: window.location.origin,
                         wombat_ts: '',
                         is_live: false,
@@ -183,6 +184,7 @@ describe('WombatJS', function () {
                         wombat_opts: {},
                         prefix: window.location.origin,
                         wombat_ts: '',
+                        wombat_scheme: 'http',
                         is_live: false,
                         top_url: ''
                     };
@@ -205,6 +207,7 @@ describe('WombatJS', function () {
                 initScript: function () {
                     wbinfo = {
                         wombat_opts: {},
+                        wombat_scheme: 'http',
                         is_live: false,
                         top_url: ''
                     };

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -505,7 +505,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             }
 
             if (href != orig_href && !starts_with(href, VALID_PREFIXES)) {
-                href = HTTP_PREFIX + href;
+                href = wb_orig_scheme + href;
             }
         }
 
@@ -514,7 +514,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         if (starts_with(href, REL_PREFIX)) {
-            href = "http:" + href;
+            href = wb_info.wombat_scheme +  ":" + href;
         }
 
         return href;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
wombat `extract_orig()` incorrectly defaults to http when unrewriting scheme-relative urls.
This is incorrect and can cause subtle issues, when the scheme is later used, such as when replaying in proxy mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Proxy mode replay of content captured from https://frick.org/calendar
can fail due to http content requested from https, due to incorrect scheme used
during capture.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
