### PR TITLE
WIP: allow symlinkinkg and hardlinking files instead of just copying

### DIFF
--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -126,8 +126,10 @@ directory structure expected by pywb
             elif method == 'symlink':
                 os.symlink(filename, os.path.join(self.archive_dir,
                                                   os.path.basename(filename)))
-            else:
+            elif method == 'copy':
                 shutil.copy2(filename, self.archive_dir)
+            else:
+                raise NotImplementedError('unknown method name: %s' % method)
             full_paths.append(os.path.join(self.archive_dir, filename))
 
         self._index_merge_warcs(full_paths, self.DEF_INDEX_FILE)

--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -117,7 +117,7 @@ directory structure expected by pywb
         for filename in warcs:
             filename = os.path.abspath(filename)
             logging.info('%s %s to %s',
-                         method,
+                         method.title(),
                          filename,
                          self.archive_dir)
             if method == 'hardlink':

--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -108,7 +108,7 @@ directory structure expected by pywb
                    'To create a new collection, run\n\n{1} init {0}')
             raise IOError(msg.format(self.coll_name, sys.argv[0]))
 
-    def add_warcs(self, warcs, hardlink=False):
+    def add_warcs(self, warcs, method='copy'):
         if not os.path.isdir(self.archive_dir):
             raise IOError('Directory {0} does not exist'.
                           format(self.archive_dir))
@@ -116,16 +116,19 @@ directory structure expected by pywb
         full_paths = []
         for filename in warcs:
             filename = os.path.abspath(filename)
-            if hardlink:
+            logging.info('%s %s to %s',
+                         method,
+                         filename,
+                         self.archive_dir)
+            if method == 'hardlink':
                 os.link(filename, os.path.join(self.archive_dir,
                                                os.path.basename(filename)))
+            elif method == 'symlink':
+                os.symlink(filename, os.path.join(self.archive_dir,
+                                                  os.path.basename(filename)))
             else:
                 shutil.copy2(filename, self.archive_dir)
             full_paths.append(os.path.join(self.archive_dir, filename))
-            logging.info('%s %s to %s',
-                         hardlink and 'Linked' or 'Copied',
-                         filename,
-                         self.archive_dir)
 
         self._index_merge_warcs(full_paths, self.DEF_INDEX_FILE)
 
@@ -364,13 +367,20 @@ Create manage file based web archive collections
     # Add Warcs
     def do_add(r):
         m = CollectionsManager(r.coll_name)
-        m.add_warcs(r.files, r.hardlink)
+        m.add_warcs(r.files, r.method)
 
     addwarc_help = 'Copy ARCS/WARCS to collection directory and reindex'
     addwarc = subparsers.add_parser('add', help=addwarc_help)
     addwarc.add_argument('coll_name')
     addwarc.add_argument('files', nargs='+')
-    addwarc.add_argument('--hardlink', '-l', action='store_true',
+    addwarc.add_argument('--method', '-m', default='copy',
+                         help='import method (default: %(default)s)',
+                         choices=('copy', 'symlink', 'hardlink'))
+    addwarc.add_argument('--symlink', '-s', action='store_const',
+                         dest='method', const='symlink',
+                         help='symlink files into storage instead of copying')
+    addwarc.add_argument('--hardlink', '-l', action='store_const',
+                         dest='method', const='hardlink',
                          help='hardlink files into storage instead of copying')
     addwarc.set_defaults(func=do_add)
 


### PR DESCRIPTION
## Description

This allows users to manage collections of large WARC files without duplicating space. Hardlinks are used instead of symlinks to reflect the original mechanism, where the file is copied (so it can be safely removed from the source). If we used symlinks, we would break that expectation which could lead to data loss.

Inversely, hardlinks can lead to data loss as well. For example, pywb could somehow edit the file, which would modify the original as well. But we assume here pywb does not modify the file, and each side of the hardlink can have their own permissions to ensure this (or not) as well.
    
Closes: #408

## Types of changes

- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
