### PR TITLE
Auto-Fetch: added picture > source[srcset] extraction and made non-proxy mode resolving of non-abs srcset URLs in the worker more robust  

### DIFF
--- a/pywb/static/autoFetchWorker.js
+++ b/pywb/static/autoFetchWorker.js
@@ -59,8 +59,6 @@ function AutoFetcher(init) {
     this.schemeless = '/' + this.relative;
     // local cache of URLs fetched, to reduce server load
     this.seen = {};
-    // array of promises returned by fetch(URL)
-    this.fetches = [];
     // array of URL to be fetched
     this.queue = [];
     // should we queue a URL or not
@@ -86,59 +84,60 @@ AutoFetcher.prototype.fixupURL = function (url) {
     return url;
 };
 
-AutoFetcher.prototype.safeFetch = function (url) {
+AutoFetcher.prototype.queueURL = function (url) {
+    // ensure we do not request data urls
+    if (url.indexOf('data:') === 0) return;
     // check to see if we have seen this url before in order
     // to lessen the load against the server content is fetched from
     if (this.seen[url] != null) return;
     this.seen[url] = true;
-    if (this.queuing) {
-        // we are currently waiting for a batch of fetches to complete
-        return this.queue.push(url);
-    }
-    // fetch this url
-    this.fetches.push(fetch(url));
+    this.queue.push(url);
 };
 
 AutoFetcher.prototype.urlExtractor = function (match, n1, n2, n3, offset, string) {
     // Same function as style_replacer in wombat.rewrite_style, n2 is our URL
-    this.safeFetch(this.fixupURL(n2));
+    this.queueURL(this.fixupURL(n2));
     return n1 + n2 + n3;
 };
 
+AutoFetcher.prototype.delay = function () {
+    // 2 second delay seem reasonable
+    return new Promise(function (resolve, reject) {
+        setTimeout(resolve, 2000);
+    });
+};
+
 AutoFetcher.prototype.fetchDone = function () {
-    // indicate we no longer need to Q
     this.queuing = false;
     if (this.queue.length > 0) {
         // we have a Q of some length drain it
-        this.drainQ();
+        var autofetcher = this;
+        this.delay().then(function () {
+            autofetcher.fetchAll();
+        });
     }
 };
 
 AutoFetcher.prototype.fetchAll = function () {
-    // if we are queuing or have no fetches this is a no op
-    if (this.queuing) return;
-    if (this.fetches.length === 0) return;
-    // we are about to fetch queue anything that comes our way
+    if (this.queuing || this.queue.length === 0) {
+        return;
+    }
+    // the number of fetches is limited to a maximum of 60 outstanding fetches
+    // the baseline maximum number of fetches is 50 but if the size(queue) <= 10
+    // we add them to the current batch
     this.queuing = true;
-    /// initiate fetches by turning the initial fetch promises
-    // into rejctionless promises and "await" all clearing
-    // our fetches array in place
     var runningFetchers = [];
-    while (this.fetches.length > 0) {
-        runningFetchers.push(this.fetches.shift().catch(noop))
+    while (this.queue.length > 0 && runningFetchers.length <= 50) {
+        runningFetchers.push(fetch(this.queue.shift()).catch(noop))
+    }
+    if (this.queue.length <= 10) {
+        while (this.queue.length > 0) {
+            runningFetchers.push(fetch(this.queue.shift()).catch(noop))
+        }
     }
     Promise.all(runningFetchers)
         .then(this.fetchDone)
         .catch(this.fetchDone);
-};
-
-AutoFetcher.prototype.drainQ = function () {
-    // clear our Q in place and fill our fetches array
-    while (this.queue.length > 0) {
-        this.fetches.push(fetch(this.queue.shift()));
-    }
-    // fetch all the things
-    this.fetchAll();
 };
 
 AutoFetcher.prototype.extractMedia = function (mediaRules) {
@@ -185,9 +184,11 @@ AutoFetcher.prototype.fixupURLSrcSet = function (url, tagSrc, context) {
             return maybeFixed;
         }
         // resolve URL against tag src
-        maybeFixed = this.maybeResolveURL(url, tagSrc);
-        if (maybeFixed != null) {
-            return this.prefix + 'im_/' + maybeFixed;
+        if (tagSrc != null) {
+            maybeFixed = this.maybeResolveURL(url, tagSrc);
+            if (maybeFixed != null) {
+                return this.prefix + 'im_/' + maybeFixed;
+            }
         }
         // finally last attempt resolve the originating documents base URI
         maybeFixed = this.maybeResolveURL(url, context.docBaseURI);
@@ -210,7 +211,7 @@ AutoFetcher.prototype.extractSrcset = function (srcsets, context) {
     // was rewrite_srcset so just ensure we just
     for (var i = 0; i < srcsetValues.length; i++) {
         // grab the URL not width/height key
-        this.safeFetch(srcsetValues[i].split(' ')[0]);
+        this.queueURL(srcsetValues[i].split(' ')[0]);
     }
 };
 
@@ -224,7 +225,7 @@ AutoFetcher.prototype.srcsetNotPreSplit = function (values, context) {
             // grab the URL not width/height key
             if (Boolean(srcsetValues[j])) {
                 var value = srcsetValues[j].trim().split(' ')[0];
-                this.safeFetch(this.fixupURLSrcSet(value, tagSrc, context));
+                this.queueURL(this.fixupURLSrcSet(value, tagSrc, context));
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Automatic fetching of picture > source[srcset] fixes #414
- added to the auto-fetch worker of both wombat and wombatProxymode
- added utility function isImageSrcset to wombat for determining if the srcset values being rewritten are from either a image tag or a source tag within a picture tag
- added utility function isImageDataSrcset to wombat to check for img/source data-srcset attributes
- reworked the backing auto-fetch worker to now queue all URLs and perform fetch batching with maximum batch size of 60. A delay of 2 seconds is applied after each batch.

Ensured that the srcset values sent to the auto-fetch worker can be resolved in non-proxy mode fixes #413
Renamed the auto-fetch class named used in proxy mode from AutoFetchWorker to AutoFetchWorkerProxyMode
Added checking of script tage types application/json and text/template to rewrite_script

Note that the utility function `isImageSrcset` added to wombat was done because the source tag (with srcset) can also be used in audio or video tag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

URL requiring change: https://www.wort.lu/de

Consider the picture tag shown below ([MDN link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture))
```html
<picture>
    <source srcset="/media/examples/surfer-240-200.jpg"
            media="(min-width: 800px)">
    <img src="/media/examples/painted-hand-298-332.jpg" />
</picture>
```
Before this PR the source[srcset] element within the picture tag was not considered a valid target for the auto-fetch system.
However, it can be used as a substitute for the srcset attribute of the img tag, that is to say, each src value of a img[srcset] is equivalent to one source tag. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
