### PR TITLE
Force absolute URLs when rewriting link href's to ensure font files are decoded correctly when response mime type does not indicate font

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -455,8 +455,11 @@ class HTMLRewriterMixin(StreamingRewriter):
 
         elif rel == 'stylesheet':
             rw_mod = 'cs_'
-
-        return self._rewrite_url(attr_value, rw_mod)
+        # ensure that we rewrite to abs because if we do not and encounter a
+        # super relative URL (href='css/stylesheet.css') under a page rooted
+        # under the mp_ modifier and the response from the server does not
+        # indicate the right mime-type, fonts et al can get messed up
+        return self._rewrite_url(attr_value, rw_mod, True)
 
     def _set_parse_context(self, tag, tag_attrs):
         # special case: script or style parse context


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Ensure that we rewrite to abs because if we do not and encounter a super relative URL (href='css/stylesheet.css') under a page rooted
under the mp_ modifier and the response from the server does not indicate the right mime-type, fonts et al can get messed up

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

fixes #424 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
