### PR TITLE
Enabled auto-fetching of video, audio resources

### DIFF
--- a/pywb/static/autoFetchWorkerProxyMode.js
+++ b/pywb/static/autoFetchWorkerProxyMode.js
@@ -3,6 +3,11 @@
 var STYLE_REGEX = /(url\s*\(\s*[\\"']*)([^)'"]+)([\\"']*\s*\))/gi;
 var IMPORT_REGEX = /(@import\s+[\\"']*)([^)'";]+)([\\"']*\s*;?)/gi;
 var srcsetSplit = /\s*(\S*\s+[\d.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))/;
+var DefaultNumImFetches = 30;
+var FullImgQDrainLen = 10;
+var DefaultNumAvFetches = 5;
+var FullAVQDrainLen = 5;
+var DataURLPrefix = 'data:';
 // the autofetcher instance for this worker
 var autofetcher = null;
 
@@ -53,24 +58,117 @@ function AutoFetcher() {
     }
     // local cache of URLs fetched, to reduce server load
     this.seen = {};
-    // array of URL to be fetched
+     // array of URLs to be fetched
     this.queue = [];
+    this.avQueue = [];
     // should we queue a URL or not
     this.queuing = false;
     // a URL to resolve relative URLs found in the cssText of CSSMedia rules.
     this.currentResolver = null;
+    // should we queue a URL or not
+    this.queuing = false;
+    this.queuingAV = false;
     this.urlExtractor = this.urlExtractor.bind(this);
-    this.fetchDone = this.fetchDone.bind(this);
+    this.imgFetchDone = this.imgFetchDone.bind(this);
+    this.avFetchDone = this.avFetchDone.bind(this);
 }
 
-AutoFetcher.prototype.queueURL = function (url) {
+AutoFetcher.prototype.delay = function () {
+    // 2 second delay seem reasonable
+    return new Promise(function (resolve, reject) {
+        setTimeout(resolve, 2000);
+    });
+};
+
+AutoFetcher.prototype.imgFetchDone = function () {
+    if (this.queue.length > 0) {
+        // we have a Q of some length drain it
+        var autofetcher = this;
+        this.delay().then(function () {
+            autofetcher.queuing = false;
+            autofetcher.fetchImgs();
+        });
+    } else {
+        this.queuing = false;
+    }
+};
+
+AutoFetcher.prototype.avFetchDone = function () {
+    if (this.avQueue.length > 0) {
+        // we have a Q of some length drain it
+        var autofetcher = this;
+        this.delay().then(function () {
+            autofetcher.queuingAV = false;
+            autofetcher.fetchAV();
+        });
+    } else {
+        this.queuingAV = false;
+    }
+};
+
+AutoFetcher.prototype.fetchAV = function () {
+    if (this.queuingAV || this.avQueue.length === 0) {
+        return;
+    }
+    // the number of fetches is limited to a maximum of DefaultNumAvFetches + FullAVQDrainLen outstanding fetches
+    // the baseline maximum number of fetches is DefaultNumAvFetches but if the size(avQueue) <= FullAVQDrainLen
+    // we add them to the current batch. Because audio video resources might be big
+    // we limit how many we fetch at a time drastically
+    this.queuingAV = true;
+    var runningFetchers = [];
+    while (this.avQueue.length > 0 && runningFetchers.length <= DefaultNumAvFetches) {
+        runningFetchers.push(fetch(this.avQueue.shift()).catch(noop))
+    }
+    if (this.avQueue.length <= FullAVQDrainLen) {
+        while (this.avQueue.length > 0) {
+            runningFetchers.push(fetch(this.avQueue.shift()).catch(noop))
+        }
+    }
+    Promise.all(runningFetchers)
+        .then(this.avFetchDone)
+        .catch(this.avFetchDone);
+};
+
+AutoFetcher.prototype.fetchImgs = function () {
+    if (this.queuing || this.queue.length === 0) {
+        return;
+    }
+    // the number of fetches is limited to a maximum of DefaultNumImFetches + FullImgQDrainLen outstanding fetches
+    // the baseline maximum number of fetches is DefaultNumImFetches but if the size(queue) <= FullImgQDrainLen
+    // we add them to the current batch
+    this.queuing = true;
+    var runningFetchers = [];
+    while (this.queue.length > 0 && runningFetchers.length <= DefaultNumImFetches) {
+        runningFetchers.push(fetch(this.queue.shift()).catch(noop))
+    }
+    if (this.queue.length <= FullImgQDrainLen) {
+        while (this.queue.length > 0) {
+            runningFetchers.push(fetch(this.queue.shift()).catch(noop))
+        }
+    }
+    Promise.all(runningFetchers)
+        .then(this.imgFetchDone)
+        .catch(this.imgFetchDone);
+};
+
+AutoFetcher.prototype.queueNonAVURL = function (url) {
     // ensure we do not request data urls
-    if (url.indexOf('data:') === 0) return;
+    if (url.indexOf(DataURLPrefix) === 0) return;
     // check to see if we have seen this url before in order
-    // to lessen the load against the server content is autofetchd from
+    // to lessen the load against the server content is fetched from
     if (this.seen[url] != null) return;
     this.seen[url] = true;
     this.queue.push(url);
+};
+
+AutoFetcher.prototype.queueAVURL = function (url) {
+    // ensure we do not request data urls
+    if (url.indexOf(DataURLPrefix) === 0) return;
+    // check to see if we have seen this url before in order
+    // to lessen the load against the server content is fetched from
+    if (this.seen[url] != null) return;
+    this.seen[url] = true;
+    this.avQueue.push(url);
 };
 
 AutoFetcher.prototype.safeResolve = function (url, resolver) {
@@ -95,50 +193,9 @@ AutoFetcher.prototype.urlExtractor = function (match, n1, n2, n3, offset, string
     // (resolvedURL will be undefined if an error occurred)
     var resolvedURL = this.safeResolve(n2, this.currentResolver);
     if (resolvedURL) {
-        this.queueURL(resolvedURL);
+        this.queueNonAVURL(resolvedURL);
     }
     return n1 + n2 + n3;
-};
-
-AutoFetcher.prototype.delay = function () {
-    // 2 second delay seem reasonable
-    return new Promise(function (resolve, reject) {
-        setTimeout(resolve, 2000);
-    });
-};
-
-AutoFetcher.prototype.fetchDone = function () {
-    this.queuing = false;
-    if (this.queue.length > 0) {
-        // we have a Q of some length drain it
-        var autofetcher = this;
-        // wait 2 seconds before doing another batch
-        this.delay().then(function () {
-            autofetcher.fetchAll();
-        });
-    }
-};
-
-AutoFetcher.prototype.fetchAll = function () {
-    if (this.queuing || this.queue.length === 0) {
-        return;
-    }
-    // the number of fetches is limited to a maximum of 60 outstanding fetches
-    // the baseline maximum number of fetches is 50 but if the size(queue) <= 10
-    // we add them to the current batch    this.queuing = true;
-    this.queuing = true;
-    var runningFetchers = [];
-    while (this.queue.length > 0 && runningFetchers.length <= 50) {
-        runningFetchers.push(fetch(this.queue.shift()).catch(noop))
-    }
-    if (this.queue.length <= 10) {
-        while (this.queue.length > 0) {
-            runningFetchers.push(fetch(this.queue.shift()).catch(noop))
-        }
-    }
-    Promise.all(runningFetchers)
-        .then(this.fetchDone)
-        .catch(this.fetchDone);
 };
 
 AutoFetcher.prototype.extractMedia = function (mediaRules) {
@@ -165,13 +222,17 @@ AutoFetcher.prototype.extractSrcset = function (srcsets) {
         extractedSrcSet = srcsets[i];
         ssSplit = extractedSrcSet.srcset.split(srcsetSplit);
         for (j = 0; j < ssSplit.length; j++) {
-            if (Boolean(ssSplit[j])) {
+            if (ssSplit[j]) {
                 srcsetValue = ssSplit[j].trim();
                 if (srcsetValue.length > 0) {
                     // resolve the URL in an exceptionless manner (resolvedURL will be undefined if an error occurred)
                     var resolvedURL = this.safeResolve(srcsetValue.split(' ')[0], extractedSrcSet.resolve);
                     if (resolvedURL) {
-                        this.queueURL(resolvedURL);
+                        if (extractedSrcSet.mod === 'im_') {
+                            this.queueNonAVURL(resolvedURL);
+                        } else {
+                            this.queueAVURL(resolvedURL);
+                        }
                     }
                 }
             }
@@ -179,12 +240,34 @@ AutoFetcher.prototype.extractSrcset = function (srcsets) {
     }
 };
 
+AutoFetcher.prototype.extractSrc = function (srcVals) {
+    // preservation worker in proxy mode sends us the value of the srcset attribute of an element
+    // and a URL to correctly resolve relative URLS. Thus we must recreate rewrite_srcset logic here
+    if (srcVals == null || srcVals.length === 0) return;
+    var length = srcVals.length;
+    var srcVal;
+    for (var i = 0; i < length; i++) {
+        srcVal = srcVals[i];
+        var resolvedURL = this.safeResolve(srcVal.src, srcVal.resolve);
+        if (resolvedURL) {
+            if (srcVal.mod === 'im_') {
+                this.queueNonAVURL(resolvedURL);
+            } else {
+                this.queueAVURL(resolvedURL);
+            }
+        }
+    }
+};
+
+
 AutoFetcher.prototype.autofetchMediaSrcset = function (data) {
     // we got a message and now we autofetch!
     // these calls turn into no ops if they have no work
     this.extractMedia(data.media);
     this.extractSrcset(data.srcset);
-    this.fetchAll();
+    this.extractSrc(data.src);
+    this.fetchImgs();
+    this.fetchAV();
 };
 
 autofetcher = new AutoFetcher();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Added auto-fetching of audio and video resources in both proxy and non-proxy mode.

Renamed `isImageSrcset` to `isSavedSrcSrcset` and `isImageDataSrcset` to `isSavedDataSrcSrcset`

Because audio/video resources can be large the backing worker now has two queues that operate independently:
- 1st is for URLs for images (`queue`), limited to a maximum of 40 concurrent fetches 
- 2nd is for URL for audio/video (`avQueue`), limited to a maximum of 10 concurrent fetches
 
In non-proxy mode `AutoFetchWorker.extractFromLocalDoc` now performs work one JS eventloop tick after the documents ready state is complete.

In both proxy and non-proxy mode `AutoFetchWorker` uses a pre-computed selector that matches all the auto-fetch element and attribute combinations
- The resolution algorithm used by the browser is to select the element on first match of a selectors clauses.    

Added `preserveDataSrcset` to `AutoFetchWorker` in non-proxy mode to aid in saving auto-fetched elements with `data-srcset` attributes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
