### PR TITLE
Check text/html content to ensure actually html

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -433,7 +433,7 @@ class RewriteInfo(object):
         # if html or no-content type, allow resolving on js, css,
         # or other templates
         if text_type == 'guess-text':
-            if not is_js_or_css and mod not in ('if_', 'mp_', ''):
+            if not is_js_or_css and mod not in ('if_', 'mp_', 'bn_', ''):
                 return None
 
         # if application/octet-stream binary, only resolve if in js/css content

--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -48,7 +48,7 @@ class DefaultRewriter(BaseContentRewriter):
 
     rewrite_types = {
         # HTML
-        'text/html': 'guess-text',
+        'text/html': 'guess-html',
         'application/xhtml': 'html',
         'application/xhtml+xml': 'html',
 

--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -48,7 +48,7 @@ class DefaultRewriter(BaseContentRewriter):
 
     rewrite_types = {
         # HTML
-        'text/html': 'html',
+        'text/html': 'guess-text',
         'application/xhtml': 'html',
         'application/xhtml+xml': 'html',
 

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -336,6 +336,16 @@ class TestContentRewriter(object):
         assert is_rw == False
         assert b''.join(gen) == content
 
+    def test_binary_wrong_content_type_html_rw(self):
+        headers = {'Content-Type': 'text/html; charset=utf-8'}
+        content = b'Hello <a href="/foo.html">link</a>'
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
+
+        assert is_rw
+        assert b''.join(gen) == b'Hello <a href="/prefix/201701/http://example.com/foo.html">link</a>'
+
     def test_binary_wrong_content_type_css(self):
         headers = {'Content-Type': 'text/css; charset=utf-8'}
         content = b'\xe9\x11\x12\x13\x14'

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -126,7 +126,7 @@ class TestContentRewriter(object):
 
         headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
 
-        assert is_rw
+        assert is_rw == False
         assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
         assert b''.join(gen).decode('utf-8') == exp
 
@@ -333,7 +333,7 @@ class TestContentRewriter(object):
 
         assert ('Content-Type', 'text/html; charset=utf-8') in headers.headers
 
-        assert is_rw == True
+        assert is_rw == False
         assert b''.join(gen) == content
 
     def test_binary_wrong_content_type_css(self):

--- a/pywb/rewrite/test/test_header_rewriter.py
+++ b/pywb/rewrite/test/test_header_rewriter.py
@@ -43,15 +43,15 @@ class TestHeaderRewriter(object):
         res = """\
 HTTP/1.0 200 OK\r\n\
 Date: Fri, 03 Jan 2014 03:03:21 GMT\r\n\
-Content-Length: 5\r\n\
+X-Archive-Orig-Content-Length: 5\r\n\
 Content-Type: text/html;charset=UTF-8\r\n\
 """
         rwinfo = self.do_rewrite('200 OK', headers)
         http_headers = DefaultHeaderRewriter(rwinfo)()
         assert str(http_headers) == res
 
-        assert rwinfo.text_type == 'html'
-        assert rwinfo.charset == 'utf-8'
+        assert rwinfo.text_type == None
+        assert rwinfo.charset == None
 
     def test_header_rewrite_redirect(self):
         headers = [('Connection', 'close'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Use same html-detection check as for text/plain before assuming content is html (similar to text/plain)

supersedes #426, fixes #424 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Occasionally binary content may be served with a mp_/ modifier as text/html. If so, it should not be treated as html and no rewriting should be attempted. Run the same html detection (check that file starts with an `<` char) as is used when modifier does not match expected mime type.
Avoid attempting to parse binary files as HTML.

FIxes #424 in more general way by ensuring fonts served via mp_/ are served underwritten binary regardless of modifier used.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
