### PR TITLE
Remove Transer-Encoding from internal response

### DIFF
--- a/pywb/recorder/recorderapp.py
+++ b/pywb/recorder/recorderapp.py
@@ -252,6 +252,10 @@ class RecorderApp(object):
 
         resp_iter = StreamIter(resp_stream)
 
+        # ensure TE header from upstream is not included,
+        # added automatically by wsgi app
+        res.headers.pop('Transfer-Encoding', '')
+
         start_response('200 OK', list(res.headers.items()))
         return resp_iter
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Ensure RecorderApp proxy response does not add Transfer-Encoding header if one is set by Warcserver, as its added automatically via WSGI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Fixes #432, only occurs with python 2.7


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
