### PR TITLE
Ensured that the HTML content brought in via a frameset's frame is rewritten 

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -434,7 +434,7 @@ class RewriteInfo(object):
         # if html or no-content type, allow resolving on js, css,
         # or other templates
         if text_type in ('guess-text', 'guess-html'):
-            if not is_js_or_css and mod not in ('if_', 'mp_', 'bn_', ''):
+            if not is_js_or_css and mod not in ('fr_', 'if_', 'mp_', 'bn_', ''):
                 return None
 
         # if application/octet-stream binary, only resolve if in js/css content

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -524,6 +524,24 @@ class TestContentRewriter(object):
 
         assert b''.join(gen).decode('utf-8') == '{"ssid":"5678"}'
 
+    def test_rewrite_frameset_frame_content(self):
+        """Determines if the content rewriter correctly determines that HTML loaded via a frameset's frame,
+        frame's src url is rewritten with the **fr_** rewrite modifier, is content to be rewritten
+        """
+        headers = {'Content-Type': 'text/html; charset=UTF-8'}
+        prefix = 'http://localhost:8080/live/'
+        dt = '20190205180554%s'
+        content = '<!DOCTYPE html><head><link rel="icon" href="http://r-u-ins.tumblr.com/img/favicon/72.png" ' \
+                  'type="image/x-icon"></head>'
+        rw_headers, gen, is_rw = self.rewrite_record(headers, content, ts=dt % 'fr_',
+                                                     prefix=prefix,
+                                                     url='http://r-u-ins.tumblr.com/',
+                                                     is_live='1')
+        # is_rw should be true indicating the content was rewritten
+        assert is_rw
+        assert b''.join(gen).decode('utf-8') == content.replace('href="', 'href="%s%s' % (prefix, dt % 'oe_/'))
+        assert rw_headers.headers == [('Content-Type', 'text/html; charset=UTF-8')]
+
     def test_custom_live_only(self):
         headers = {'Content-Type': 'application/json'}
         content = '{"foo":"bar", "dash": {"on": "true"}, "some": ["list"]'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

Because the rewrite modifier `fr_` was not included in the acceptable modifiers for `guess-text` and `guess-html`, RewriteInfo believed that content under the `fr_` modifier was not to be rewritten.

## Description
<!--- Describe your changes in detail -->

Updated RewriteInfo._resolve_text_type to recognize the `fr_` rewrite modifier (indicates that the content is from a frameset's frame) as content to be rewritten

Added a test, test_rewrite_frameset_frame_content, to test_content_rewriter.py for these changes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

URL requiring change: http://r-u-ins.link/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
