### PR TITLE
Brotli: Don't accept brotli if library can't be loaded.

### DIFF
--- a/pywb/rewrite/rewriteinputreq.py
+++ b/pywb/rewrite/rewriteinputreq.py
@@ -5,10 +5,11 @@ from six import iteritems
 from six.moves.urllib.parse import urlsplit
 import re
 
+
 try: # pragma: no cover
     import brotli
     has_brotli = True
-except:  # pragma: no cover
+except Exception:  # pragma: no cover
     has_brotli = False
     print('Warning: brotli module could not be loaded, will not be able to replay brotli-encoded content')
 

--- a/pywb/rewrite/rewriteinputreq.py
+++ b/pywb/rewrite/rewriteinputreq.py
@@ -87,7 +87,8 @@ class RewriteInputRequest(DirectWSGIInputRequest):
                     value = self.splits.scheme
 
             elif not has_brotli and name == 'HTTP_ACCEPT_ENCODING' and 'br' in value:
-                # if brotli not available, remove brotli encoded content
+                # if brotli not available, remove 'br' from accept-encoding to avoid
+                # capture brotli encoded content
                 name = 'Accept-Encoding'
                 value = ','.join([enc for enc in value.split(',') if enc.strip() != 'br'])
 

--- a/pywb/rewrite/rewriteinputreq.py
+++ b/pywb/rewrite/rewriteinputreq.py
@@ -5,6 +5,13 @@ from six import iteritems
 from six.moves.urllib.parse import urlsplit
 import re
 
+try: # pragma: no cover
+    import brotli
+    has_brotli = True
+except:  # pragma: no cover
+    has_brotli = False
+    print('Warning: brotli module could not be loaded, will not be able to replay brotli-encoded content')
+
 
 #=============================================================================
 class RewriteInputRequest(DirectWSGIInputRequest):
@@ -78,6 +85,11 @@ class RewriteInputRequest(DirectWSGIInputRequest):
                 name = 'X-Forwarded-Proto'
                 if self.splits:
                     value = self.splits.scheme
+
+            elif not has_brotli and name == 'HTTP_ACCEPT_ENCODING' and 'br' in value:
+                # if brotli not available, remove brotli encoded content
+                name = 'Accept-Encoding'
+                value = ','.join([enc for enc in value.split(',') if enc.strip() != 'br'])
 
             elif name.startswith('HTTP_'):
                 name = name[5:].title().replace('_', '-')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
If `import brotli` fails, print warning and remove `br` from `Accept-Encoding`
Otherwise, can fail silently when trying to record/replay brotli content.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
See #434

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
