### PR TITLE
JSONP Rewriter: Fix regex to match both /* and // comments

### DIFF
--- a/pywb/rewrite/jsonp_rewriter.py
+++ b/pywb/rewrite/jsonp_rewriter.py
@@ -5,13 +5,13 @@ from pywb.rewrite.content_rewriter import StreamingRewriter
 # ============================================================================
 class JSONPRewriter(StreamingRewriter):
     #JSONP = re.compile(r'^(?:\s*\/\*(?:.*)\*\/)*\s*(\w+)\(\{')
-    # Match /* and // style comments at the beginning
-    JSONP = re.compile(r'^(?:(?:\/\*[\w\'\s\r\n\*]*\*\/)|(?:\/\/[^\n]*))\s*(\w+)\(\{', re.M)
+    # Match a single /* and // style comments at the beginning
+    JSONP = re.compile(r'(?:^[ \t]*(?:(?:\/\*[^\*]*\*\/)|(?:\/\/[^\n]+[\n])))*[ \t]*(\w+)\(\{', re.M)
     CALLBACK = re.compile(r'[?].*callback=([^&]+)')
 
     def rewrite(self, string):
         # see if json is jsonp, starts with callback func
-        m_json = self.JSONP.search(string)
+        m_json = self.JSONP.match(string)
         if not m_json:
             return string
 

--- a/pywb/rewrite/jsonp_rewriter.py
+++ b/pywb/rewrite/jsonp_rewriter.py
@@ -4,7 +4,9 @@ from pywb.rewrite.content_rewriter import StreamingRewriter
 
 # ============================================================================
 class JSONPRewriter(StreamingRewriter):
-    JSONP = re.compile(r'^(?:\s*\/\*(?:.*)\*\/)*\s*(\w+)\(\{')
+    #JSONP = re.compile(r'^(?:\s*\/\*(?:.*)\*\/)*\s*(\w+)\(\{')
+    # Match /* and // style comments at the beginning
+    JSONP = re.compile(r'^(?:(?:\/\*[\w\'\s\r\n\*]*\*\/)|(?:\/\/[^\n]*))\s*(\w+)\(\{', re.M)
     CALLBACK = re.compile(r'[?].*callback=([^&]+)')
 
     def rewrite(self, string):

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -459,7 +459,23 @@ class TestContentRewriter(object):
 
     def test_rewrite_js_as_json_generic_jsonp(self):
         headers = {'Content-Type': 'application/json'}
-        content = '/**/ jsonpCallbackABCDEF({"foo": "bar"});'
+        content = '/*abc*/ jsonpCallbackABCDEF({"foo": "bar"});'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701js_',
+                                                  url='http://example.com/path/file?callback=jsonpCallback12345')
+
+        # content-type unchanged
+        assert ('Content-Type', 'application/json') in headers.headers
+
+        exp = 'jsonpCallback12345({"foo": "bar"});'
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_js_as_json_generic_jsonp_multiline_comment(self):
+        headers = {'Content-Type': 'application/json'}
+        content = """\
+// A comment
+// Another?
+jsonpCallbackABCDEF({"foo": "bar"});"""
 
         headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701js_',
                                                   url='http://example.com/path/file?callback=jsonpCallback12345')

--- a/pywb/rewrite/test/test_jsonp_rewriter.py
+++ b/pywb/rewrite/test/test_jsonp_rewriter.py
@@ -8,10 +8,15 @@ class TestJSONPRewriter(object):
         cls.rewriter = JSONPRewriter(urlrewriter)
 
         urlrewriter = UrlRewriter('20161226/http://example.com/', '/web/', 'https://localhost/web/')
-        cls.rewriter_no_cb = JSONPRewriter(urlrewriter)
+        cls.rewriter_missing_cb = JSONPRewriter(urlrewriter)
 
     def test_jsonp_rewrite_1(self):
         string = 'jQuery_1234({"foo": "bar", "some": "data"})'
+        expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
+        assert self.rewriter.rewrite(string) == expect
+
+    def test_jsonp_rewrite_1_with_whitespace(self):
+        string = '    jQuery_1234({"foo": "bar", "some": "data"})'
         expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
         assert self.rewriter.rewrite(string) == expect
 
@@ -25,6 +30,34 @@ class TestJSONPRewriter(object):
         expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
         assert self.rewriter.rewrite(string) == expect
 
+    def test_jsonp_rewrite_4(self):
+        string = """// some comment
+ jQuery_1234({"foo": "bar", "some": "data"})"""
+        expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
+        assert self.rewriter.rewrite(string) == expect
+
+    def test_jsonp_rewrite_5(self):
+        string = """// some comment
+ // blah = 4;
+ jQuery_1234({"foo": "bar", "some": "data"})"""
+        expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
+        assert self.rewriter.rewrite(string) == expect
+
+# JSONP valid but 'callback=' missing in url tests
+    def test_no_jsonp_rewrite_missing_callback_1(self):
+        """ JSONP valid but callback is missing in url
+        """
+        string = 'jQuery_1234({"foo": "bar", "some": "data"})'
+        assert self.rewriter_missing_cb.rewrite(string) == string
+
+    def test_no_jsonp_rewrite_missing_callback_2(self):
+        string = """// some comment
+ jQuery_1234({"foo": "bar", "some": "data"})"""
+        expect = 'jQuery_ABC({"foo": "bar", "some": "data"})'
+        assert self.rewriter_missing_cb.rewrite(string) == string
+
+
+# Invalid JSONP Tests
     def test_no_jsonp_rewrite_1(self):
         string = ' /* comment jQuery_1234({"foo": "bar", "some": "data"})'
         assert self.rewriter.rewrite(string) == string
@@ -37,8 +70,14 @@ class TestJSONPRewriter(object):
         string = 'var foo = ({"foo": "bar", "some": "data"})'
         assert self.rewriter.rewrite(string) == string
 
-    def test_no_jsonp_rewrite_no_callback_1(self):
-        string = 'jQuery_1234({"foo": "bar", "some": "data"})'
-        assert self.rewriter_no_cb.rewrite(string) == string
+    def test_jsonp_rewrite_3(self):
+        string = ' abc /* some comment */ jQuery_1234({"foo": "bar", "some": "data"})'
+        assert self.rewriter.rewrite(string) == string
+
+    def test_no_jsonp_multiline_rewrite_2(self):
+        string = """// some comment
+ blah = 4;
+ jQuery_1234({"foo": "bar", "some": "data"})"""
+        assert self.rewriter.rewrite(string) == string
 
 


### PR DESCRIPTION

## Description
JSONP Rewriter before only allowed matching function being matched, eg. `/* comment */ jQuery({`
Also support matching JSONP:
```
// Comment
jQuery({
```
as browsers also accept this as JSONP

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Fixes replay issue in #459 

https://www.newblackmaninexile.net/


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
