### PR TITLE
CookieError logging

### DIFF
--- a/pywb/rewrite/cookie_rewriter.py
+++ b/pywb/rewrite/cookie_rewriter.py
@@ -2,6 +2,9 @@ from six.moves.http_cookies import SimpleCookie, CookieError
 import six
 import re
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 #================================================================
 class WbUrlBaseCookieRewriter(object):
@@ -17,9 +20,8 @@ class WbUrlBaseCookieRewriter(object):
         cookie_str = self.REMOVE_EXPIRES.sub('', cookie_str)
         try:
             cookie = SimpleCookie(cookie_str)
-        except CookieError:
-            import traceback
-            traceback.print_exc()
+        except CookieError as e:
+            logger.info(e, exc_info=True)
             return results
 
         for name, morsel in six.iteritems(cookie):


### PR DESCRIPTION
## Description, Motivation and Context
A number of websites routinely set cookies with technically invalid characters in the name. For instance, 'ballotbox/respondent_id'`, is set by https://fox13now.com/2017/08/24/federal-appeals-court-upholds-injunction-against-vidangels-streaming-service/. Browsers don't generally object, but python does.

Pywb is prepared for such cookies and [catches the exception](https://github.com/webrecorder/pywb/blob/master/pywb/rewrite/cookie_rewriter.py#L20), but presently prints a stack trace to stdout every time.

This PR switches from `traceback.print_exc()` to `logger.info(e, exc_info=True)` to give pywb users more control over this logging, including the ability to suppress it.

(Contributed as part of our interest in funneling all Pywb/Webrecorder logs through python's logging module, so as to reduce output, and in preparation for directing logs to an aggregation system.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(none of the above)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
