### PR TITLE
Proposed: More detailed logging of invalid cdxlines.

### DIFF
--- a/pywb/warcserver/index/cdxobject.py
+++ b/pywb/warcserver/index/cdxobject.py
@@ -149,7 +149,7 @@ class CDXObject(OrderedDict):
                 cdxformat = i
 
         if not cdxformat:
-            msg = 'unknown {0}-field cdx format'.format(len(fields))
+            msg = 'unknown {0}-field cdx format: {1}'.format(len(fields), fields)
             raise CDXException(msg)
 
         for header, field in zip(cdxformat, fields):


### PR DESCRIPTION
## Description, Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

We recently encountered a number of warcs that (due to a separate issue to be discussed over at the warcio repo 🙂), when imported into Webrecorder, caused invalid cdxline byte strings to be passed to `CDXObject.__init__()`

By logging `fields` here, in addition to `len(fields)`, we were more easily able to track down which warcs were causing problems, and were more easily able to identify what the problem was. (FWIW: unencoded spaces in the target url).

While it seems pretty unlikely that anybody else will have the same problem we did, it does seem likely that anybody dealing with invalid cdxlines will benefit from seeing bad data logged here in its entirety.

So! In case you care to add it, here's a PR that adds that little bit of extra logging.

If you don't care to add it, totally feel free to just close this!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(none of the above)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
