### PR TITLE
Fix #471: failed playback due to encoding issue

### DIFF
--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -234,6 +234,7 @@ class MethodQueryCanonicalizer(object):
                 query = unquote_plus(query)
             except UnicodeDecodeError:
                 query = to_native_str(query, 'iso-8859-1')
+                query = unquote_plus(query, 'iso-8859-1')
 
         elif mime.startswith('multipart/'):
             env = {'REQUEST_METHOD': 'POST',

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -236,7 +236,7 @@ class MethodQueryCanonicalizer(object):
 
         if mime.startswith('application/x-www-form-urlencoded'):
             try:
-                query = to_native_str(query)
+                query = to_native_str(query.decode())
                 query = unquote_plus(query)
             except UnicodeDecodeError:
                 query = handle_binary(query)

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -229,8 +229,11 @@ class MethodQueryCanonicalizer(object):
             mime = ''
 
         if mime.startswith('application/x-www-form-urlencoded'):
-            query = to_native_str(query)
-            query = unquote_plus(query)
+            try:
+                query = to_native_str(query)
+                query = unquote_plus(query)
+            except UnicodeDecodeError:
+                query = to_native_str(query, 'iso-8859-1')
 
         elif mime.startswith('multipart/'):
             env = {'REQUEST_METHOD': 'POST',

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -236,7 +236,7 @@ class MethodQueryCanonicalizer(object):
 
         if mime.startswith('application/x-www-form-urlencoded'):
             try:
-                query = to_native_str(query.decode())
+                query = to_native_str(query.decode('utf-8'))
                 query = unquote_plus(query)
             except UnicodeDecodeError:
                 query = handle_binary(query)

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -228,13 +228,18 @@ class MethodQueryCanonicalizer(object):
         if not mime:
             mime = ''
 
+        def handle_binary(query):
+            query = base64.b64encode(query)
+            query = to_native_str(query)
+            query = '__wb_post_data=' + query
+            return query
+
         if mime.startswith('application/x-www-form-urlencoded'):
             try:
                 query = to_native_str(query)
                 query = unquote_plus(query)
             except UnicodeDecodeError:
-                query = to_native_str(query, 'iso-8859-1')
-                query = unquote_plus(query, 'iso-8859-1')
+                query = handle_binary(query)
 
         elif mime.startswith('multipart/'):
             env = {'REQUEST_METHOD': 'POST',
@@ -260,9 +265,7 @@ class MethodQueryCanonicalizer(object):
             query = self.amf_parse(query, environ)
 
         else:
-            query = base64.b64encode(query)
-            query = to_native_str(query)
-            query = '__wb_post_data=' + query
+            query = handle_binary(query)
 
         self.query = query
 

--- a/pywb/warcserver/test/test_inputreq.py
+++ b/pywb/warcserver/test/test_inputreq.py
@@ -6,7 +6,7 @@ from six.moves.urllib.parse import parse_qsl
 from io import BytesIO
 from pyamf import AMF3
 from pyamf.remoting import Request, Envelope, encode
-
+from warcio.utils import to_native_str
 
 #=============================================================================
 class InputReqApp(object):
@@ -140,7 +140,7 @@ class TestPostQueryExtract(object):
         mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
                                 len(data), BytesIO(data))
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?\x816l`L\xa04P\x0eàr\x02µ\x89\x19\x00fPÛ\x0e°\x02,'
+        assert mq.append_query('http://example.com/') == 'http://example.com/?' + to_native_str(data, 'iso-8859-1')
 
     def test_options(self):
         mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())

--- a/pywb/warcserver/test/test_inputreq.py
+++ b/pywb/warcserver/test/test_inputreq.py
@@ -135,6 +135,13 @@ class TestPostQueryExtract(object):
 
         assert mq.append_query('http://example.com/') == 'http://example.com/?foo=bar&dir=/baz'
 
+    def test_post_extract_malformed_form_data(self):
+        data = b"\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,"
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                len(data), BytesIO(data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?\x816l`L\xa04P\x0eàr\x02µ\x89\x19\x00fPÛ\x0e°\x02,'
+
     def test_options(self):
         mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())
         assert mq.append_query('http://example.com/') == 'http://example.com/?__pywb_method=options'

--- a/pywb/warcserver/test/test_inputreq.py
+++ b/pywb/warcserver/test/test_inputreq.py
@@ -6,7 +6,7 @@ from six.moves.urllib.parse import parse_qsl
 from io import BytesIO
 from pyamf import AMF3
 from pyamf.remoting import Request, Envelope, encode
-from warcio.utils import to_native_str
+
 
 #=============================================================================
 class InputReqApp(object):
@@ -83,6 +83,7 @@ class TestPostQueryExtract(object):
     @classmethod
     def setup_class(cls):
         cls.post_data = b'foo=bar&dir=%2Fbaz'
+        cls.binary_post_data = b'\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,'
 
     def test_post_extract_1(self):
         mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
@@ -136,11 +137,11 @@ class TestPostQueryExtract(object):
         assert mq.append_query('http://example.com/') == 'http://example.com/?foo=bar&dir=/baz'
 
     def test_post_extract_malformed_form_data(self):
-        data = b"\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,"
         mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                len(data), BytesIO(data))
+                                len(self.binary_post_data), BytesIO(self.binary_post_data))
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?' + to_native_str(data, 'iso-8859-1')
+        #base64 encoded data
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw='
 
     def test_options(self):
         mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())


### PR DESCRIPTION
## Description, Motivation and Context

This is a first pass at resolving #471

The new test intentionally demonstrates that this is a more of a workaround than a real "solution" per se.... what a weird-looking, useless query string... Even though this permits playback to proceed (and restores the behavior of earlier versions of pywb), I wonder if we might be able to do better by base64-encoding it and appending it to __wb_post_data= as in the else clause... but I'm not really qualified to speculate on these topics at this point lol.

Happy to iterate on this / adjust in any way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
