### PR TITLE
Wombat Improvements for extractOriginalUrl and hash change

### DIFF
--- a/wombat/src/wombat.js
+++ b/wombat/src/wombat.js
@@ -906,8 +906,16 @@ Wombat.prototype.extractOriginalURL = function(rewrittenUrl) {
     return url;
   }
 
-  // if no coll, start from beginning, otherwise could be part of coll..
-  var start = this.wb_rel_prefix ? 1 : 0;
+  var start;
+
+  if (this.startsWith(url, this.wb_abs_prefix)) {
+    start = this.wb_abs_prefix.length;
+  } else if (this.wb_rel_prefix && this.startsWith(url, this.wb_rel_prefix)) {
+    start = this.wb_rel_prefix.length;
+  } else {
+    // if no coll, start from beginning, otherwise could be part of coll..
+    start = this.wb_rel_prefix ? 1 : 0;
+  }
 
   var index = url.indexOf('/http', start);
   if (index < 0) {
@@ -4776,11 +4784,11 @@ Wombat.prototype.initHashChange = function() {
   var receive_hash_change = function receive_hash_change(event) {
     var source = wombat.proxyToObj(event.source);
 
-    if (!event.data || source !== wombat.$wbwindow.__WB_top_frame) {
+    if (!event.data || !event.data.from_top) {
       return;
     }
 
-    var message = event.data;
+    var message = event.data.message;
 
     if (!message.wb_type) return;
 

--- a/wombat/src/wombat.js
+++ b/wombat/src/wombat.js
@@ -4782,7 +4782,6 @@ Wombat.prototype.initHashChange = function() {
   var wombat = this;
 
   var receive_hash_change = function receive_hash_change(event) {
-    var source = wombat.proxyToObj(event.source);
 
     if (!event.data || !event.data.from_top) {
       return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
This PR fixes two issues:
- extractOriginalUrl() now takes into account the abs or rel prefix, if available, in determining the original url. The original url, eg: `http://realoriginal.example.com/` is extracted properly from `http://example.com/1234/http://another.example.com/4567/http://realoriginal.example.com/`
given prefix `http://example.com/1234/http://another.example.com/`.

- Since initHashChange/receive_hash_change() are registered before message event overrides,
check the wrapped message directly via .from_top to determine if it came from top frame.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
