### PR TITLE
Update configuring.rst to reflect default config.yaml.

### DIFF
--- a/docs/manual/configuring.rst
+++ b/docs/manual/configuring.rst
@@ -53,7 +53,7 @@ The default directory structure for a web archive is as follows::
         |
         +-- <coll name>
             |
-            +-- archives
+            +-- archive
             |     |
             |     +-- (WARC or ARC files here)
             |


### PR DESCRIPTION
The Docs specify the default value for the warc files path as 'archives' but the default config.yaml file specifies 'archive'
https://github.com/webrecorder/pywb/blob/master/pywb/default_config.yaml#L4
