### PR TITLE
Server side regex rewriting tweak for JavaScript eval

### DIFF
--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -103,9 +103,9 @@ if (thisObj && thisObj._WB_wombat_obj_proxy) return thisObj._WB_wombat_obj_proxy
 
         rules = [
             # rewriting 'eval(....)' - invocation
-            (r'\beval\s*\(', self.add_prefix('WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).'), 0),
+            (r'(?<![$])\beval\s*\(', self.add_prefix('WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).'), 0),
             # rewriting 'x = eval' - no invocation
-            (r'\beval\b', self.add_prefix('WB_wombat_'), 0),
+            (r'(?<![$])\beval\b', self.add_prefix('WB_wombat_'), 0),
             (r'(?<=\.)postMessage\b\(', self.add_prefix('__WB_pmw(self).'), 0),
             (r'(?<![$.])\s*location\b\s*[=]\s*(?![=])', self.add_suffix(check_loc), 0),
             # rewriting 'return this'

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -212,7 +212,23 @@ r"""
 >>> _test_js_obj_proxy(r'this. location = http://example.com/')
 'this. location = ((self.__WB_check_loc && self.__WB_check_loc(location)) || {}).href = http://example.com/'
 
+>>> _test_js_obj_proxy('eval(a)')
+'WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).eval(a)'
 
+>>> _test_js_obj_proxy('this.$eval(a)')
+'this.$eval(a)'
+
+>>> _test_js_obj_proxy('x = this.$eval; x(a);')
+'x = this.$eval; x(a);'
+
+>>> _test_js_obj_proxy('x = eval; x(a);')
+'x = WB_wombat_eval; x(a);'
+
+>>> _test_js_obj_proxy('$eval = eval; $eval(a);')
+'$eval = WB_wombat_eval; $eval(a);'
+
+>>> _test_js_obj_proxy('window.eval(a);')
+'window.WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).eval(a);'
 
 #=================================================================
 # XML Rewriting


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Ensured that the regular expressions for rewriting JavaScript eval us…age do not match when prefixed with ".$"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Angular uses a function `$eval` to perform its magic, more specifically as `this.$eval`.
Rewriting this instance of `eval` is incorrect and with these changes Angular's usage `.$eval` is not rewritten. 


URLs requiring change
- https://webrecorder.io/mirrorsedgefan/mirrorsedge/list/bookmarks/b5/20180401180131/http://www.mirrorsedge.com/intel/the-conglomerate
- https://webrecorder.io/CHArchives/carnegie-hall---performance-history-search-2018/list/all-pages/b2/20180514153214/https://ektpreprod.corp.carnegiehall.org/PerformanceHistorySearch/#
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
