### PR TITLE
proxy mode HTMLInsertOnlyRewriter:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+pywb 2.3.3 changelist
+~~~~~~~~~~~~~~~~~~~~~
+
+* Proxy Mode: Ensure head insert added even if no ``<head>`` tag, insert after first tag that is not ``<html>`` or ``<head>`` (#496)
+
+
 pywb 2.3.2 changelist
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pywb/rewrite/html_insert_rewriter.py
+++ b/pywb/rewrite/html_insert_rewriter.py
@@ -4,10 +4,10 @@ from pywb.rewrite.content_rewriter import StreamingRewriter
 
 # ============================================================================
 class HTMLInsertOnlyRewriter(StreamingRewriter):
-    """ Insert custom string into HTML <head> tag
+    """ Insert custom string into HTML into the head, before any tag not <head> or <html>
         no other rewriting performed
     """
-    HEAD_REGEX = re.compile('<\s*head\\b[^>]*[>]+', re.I)
+    NOT_HEAD_REGEX = re.compile(r'(<\s*\b)(?!(html|head))', re.I)
 
     def __init__(self, url_rewriter, **kwargs):
         super(HTMLInsertOnlyRewriter, self).__init__(url_rewriter, False)
@@ -19,16 +19,16 @@ class HTMLInsertOnlyRewriter(StreamingRewriter):
         if self.done:
             return string
 
-        # only try to find <head> in first buffer
-        self.done = True
-        m = self.HEAD_REGEX.search(string)
+        m = self.NOT_HEAD_REGEX.search(string)
         if m:
-            inx = m.end()
+            inx = m.start()
             buff = string[:inx]
             buff += self.head_insert
             buff += string[inx:]
+            self.done = True
             return buff
         else:
             return string
 
-
+    def final_read(self):
+        return '' if self.done else self.head_insert

--- a/pywb/rewrite/test/test_html_insert_rewriter.py
+++ b/pywb/rewrite/test/test_html_insert_rewriter.py
@@ -1,0 +1,30 @@
+
+
+
+r'''
+>>> parse('<html><head><some-tag></head</html>')
+'<html><head><!--Insert--><some-tag></head</html>'
+
+>>> parse('<HTML><A Href="page.html">Text</a></hTmL>')
+'<HTML><!--Insert--><A Href="page.html">Text</a></hTmL>'
+
+>>> parse('<html>   <  head>  <link>')
+'<html>   <  head>  <!--Insert--><link>'
+
+>>> parse('<  head>  <link> <html>')
+'<  head>  <!--Insert--><link> <html>'
+
+>>> parse('<head></head>text')
+'<head></head>text<!--Insert-->'
+'''
+
+from pywb.rewrite.url_rewriter import UrlRewriter
+from pywb.rewrite.html_insert_rewriter import HTMLInsertOnlyRewriter
+
+def parse(html_text):
+    urlrewriter = UrlRewriter('20131226101010/https://example.com/some/path.html', '/web/')
+
+    rewriter = HTMLInsertOnlyRewriter(urlrewriter, head_insert='<!--Insert-->')
+
+    return rewriter.rewrite(html_text) + rewriter.final_read()
+

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Ensure HTMLInsertOnlyRewriter handles pages with no `<head>` tag, insert
head-insert before first tag that is not `<head>` or `<html>`, similar to full
HTMLRewriter

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Many pages (eg. new twitter.com) do not include a head tag!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
