### PR TITLE
Tweak cookie cacheing to exclude service workers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,10 @@ pywb 2.3.4 changelist
 
 * Improvements to auto-fetch to support page fetch (webrecroder/wombat#5, #497)
   - Support fetching page with ``X-Wombat-History-Page`` and title ``X-Wombat-History-Title`` headers present.
-  - Attempt to extract title and pass along with cdx to ``_add_history_page()`` callback in RewriterApp, to indicate a url is a page.
+  - Attempt to extract title and pass along with cdx to ``_add_history_page()`` callback in RewriterApp, to indicate a url is a page. (#498)
   - General auto-fetch fixes: queue messages if worker not yet inited (in proxy mode), only parse <link> stylesheet hrefs as sheets.
+
+* Cookie Rewriting Fix: don't update cookie cache on service worker (``sw_`` modifier) responses (#499)
 
 
 pywb 2.3.3 changelist

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -383,9 +383,9 @@ class RewriterApp(object):
 
         cookie_rewriter = None
         if self.cookie_tracker and cookie_key:
-            # skip add cookie if service worker is not 200 -- sw will not be loaded by browser
-            # so don't update any cookies for it
-            if wb_url.mod == 'sw_' and record.http_headers.get_statuscode() != '200':
+            # skip add cookie if service worker is not 200
+            # it seems cookie headers from service workers are not applied, so don't update in cache
+            if wb_url.mod == 'sw_':
                 cookie_key = None
 
             cookie_rewriter = self.cookie_tracker.get_rewriter(urlrewriter,


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
The domain cookie cache (revampled in 2.3.3) excluded service workers if non-200 response.
It appears that cookie headers should be excluded form cacheing for all sw responses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
This fix fixes login through pywb to Twitter, which uses domain-level cookies and service workers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
