### PR TITLE
SOCKS Proxy Improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 pywb 2.3.5 changelist
 ~~~~~~~~~~~~~~~~~~~~~
 
-* General auto-fetch fixes
+* General auto-fetch fixes (#503)
   - Fixed issue that caused HTTP 404 errors to happen when parsing <link> stylesheet hrefs as sheets (webrecorder/wombat #11)
   - Ensured that requests made are cached by the browser (webrecorder/wombat #13 & #15)
   - Ensured that the request made by the backing web worker when in proxy mode are not blocked by CORS (webrecorder/wombat #13 & #15)
+
+* SOCKS proxy fixes (#504)
+  - simplify SOCKS config (avoiding global socket monkey patch), default to no cert verify to match non-proxy behavior
+  - SOCKS proxy can be disabled dynamically by setting SOCKS_DISABLE
 
 
 pywb 2.3.4 changelist

--- a/pywb/warcserver/http.py
+++ b/pywb/warcserver/http.py
@@ -8,15 +8,16 @@ from urllib3.poolmanager import PoolManager
 six.moves.http_client._MAXHEADERS = 10000
 six.moves.http_client._MAXLINE = 131072
 
-SOCKS_PROXIES = None
-orig_getaddrinfo = None
 
-
+# =============================================================================
 class PywbHttpAdapter(HTTPAdapter):
     """This adaptor exists exists to restore the default behavior
     of urllib3 < 1.25.x, which was to not verify ssl certs,
     until a better solution is found
     """
+
+    # todo: allow configuring this later?
+    cert_reqs = 'CERT_NONE'
 
     def init_poolmanager(
         self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs
@@ -29,9 +30,13 @@ class PywbHttpAdapter(HTTPAdapter):
             maxsize=maxsize,
             block=block,
             strict=True,
-            cert_reqs='CERT_NONE',
+            cert_reqs=self.cert_reqs,
             **pool_kwargs
         )
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        proxy_kwargs['cert_reqs'] = self.cert_reqs
+        return super(PywbHttpAdapter, self).proxy_manager_for(proxy, **proxy_kwargs)
 
 
 # =============================================================================
@@ -42,61 +47,3 @@ class DefaultAdapters(object):
 
 requests.packages.urllib3.disable_warnings()
 
-
-# =============================================================================
-def patch_socks():
-    try:
-        import socks
-    except ImportError:  # pragma: no cover
-        print('Ignoring SOCKS_HOST: PySocks must be installed to use SOCKS proxy')
-        return
-
-    import socket
-
-    socks_host = os.environ.get('SOCKS_HOST')
-    socks_port = os.environ.get('SOCKS_PORT', 9050)
-
-    # Set socks proxy and wrap the urllib module
-    socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, socks_host, socks_port, True)
-    # socket.socket = socks.socksocket # sets default socket to be the sockipy socket
-
-    # store original getaddrinfo
-    global orig_getaddrinfo
-    orig_getaddrinfo = socks.socket.getaddrinfo
-
-    # Perform DNS resolution through socket
-    def getaddrinfo(*args):
-        if args[0] in ('127.0.0.1', 'localhost'):
-            res = orig_getaddrinfo(*args)
-
-        else:
-            res = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (args[0], args[1]))]
-
-        return res
-
-    socks.socket.getaddrinfo = getaddrinfo
-
-    socks_url = 'socks5h://{0}:{1}'.format(socks_host, socks_port)
-
-    global SOCKS_PROXIES
-    SOCKS_PROXIES = {'http': socks_url, 'https': socks_url}
-
-
-# =============================================================================
-def unpatch_socks():
-    global orig_getaddrinfo
-    if not orig_getaddrinfo:
-        return
-
-    import socks
-
-    socks.socket.getaddrinfo = orig_getaddrinfo
-    orig_getaddrinfo = None
-
-    global SOCKS_PROXIES
-    SOCKS_PROXIES = None
-
-
-# =============================================================================
-if os.environ.get('SOCKS_HOST'):
-    patch_socks()

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -483,23 +483,24 @@ class LiveWebLoader(BaseLoader):
         adapter = DefaultAdapters.live_adapter if is_live else DefaultAdapters.remote_adapter
         max_retries = adapter.max_retries
 
+        # get either the poolmanager or proxy manager to handle this connection
         if self.socks_proxy and not os.environ.get('SOCKS_DISABLE'):
-            conn = adapter.proxy_manager_for(self.socks_proxy)
+            manager = adapter.proxy_manager_for(self.socks_proxy)
         else:
-            conn = adapter.poolmanager
+            manager = adapter.poolmanager
 
         upstream_res = None
         try:
-            upstream_res = conn.urlopen(method=method,
-                                        url=load_url,
-                                        body=data,
-                                        headers=req_headers,
-                                        redirect=False,
-                                        assert_same_host=False,
-                                        preload_content=False,
-                                        decode_content=False,
-                                        retries=max_retries,
-                                        timeout=params.get('_timeout'))
+            upstream_res = manager.urlopen(method=method,
+                                           url=load_url,
+                                           body=data,
+                                           headers=req_headers,
+                                           redirect=False,
+                                           assert_same_host=False,
+                                           preload_content=False,
+                                           decode_content=False,
+                                           retries=max_retries,
+                                           timeout=params.get('_timeout'))
 
             return upstream_res
 

--- a/tests/test_socks.py
+++ b/tests/test_socks.py
@@ -1,9 +1,6 @@
 from .base_config_test import BaseConfigTest, fmod_sl
 
-import pywb.warcserver.http as pywb_http
 import os
-import socket
-import gevent
 import pytest
 
 
@@ -15,24 +12,24 @@ class TestSOCKSProxy(BaseConfigTest):
         os.environ['SOCKS_HOST'] = 'localhost'
         os.environ['SOCKS_PORT'] = '0'
 
-        pywb_http.patch_socks()
-        import pywb.warcserver.resource.responseloader
-        pywb.warcserver.resource.responseloader.SOCKS_PROXIES = pywb_http.SOCKS_PROXIES
         super(TestSOCKSProxy, cls).setup_class('config_test.yaml')
 
     @classmethod
     def teardown_class(cls):
-        pywb_http.unpatch_socks()
         super(TestSOCKSProxy, cls).teardown_class()
-
-    def test_socks_proxy_set(self):
-        assert pywb_http.SOCKS_PROXIES == {'http': 'socks5h://localhost:0',
-                                           'https': 'socks5h://localhost:0'
-                                          }
 
     def test_socks_attempt_connect(self, fmod_sl):
         # no proxy is set, expect to fail if socks is being used
         resp = self.get('/live/{0}http://httpbin.org/get', fmod_sl, status=400)
         assert resp.status_int == 400
 
+    def test_socks_disable_enable(self, fmod_sl):
+        os.environ['SOCKS_DISABLE'] = '1'
 
+        resp = self.get('/live/{0}http://httpbin.org/get', fmod_sl, status=200)
+        assert resp.status_int == 200
+
+        os.environ['SOCKS_DISABLE'] = ''
+
+        resp = self.get('/live/{0}http://httpbin.org/get', fmod_sl, status=400)
+        assert resp.status_int == 400


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
Improves the SOCKS proxy handling:
- https urls over SOCKS were sometimes improperly sent using full url, using higher-level adapter to avoid this
- ensure SOCKS proxy uses same cert verification mode as non proxy (currently no checking).
- removed unnecessary monkey patching, as requests/urllib3 now support socks5 without patching.
- also add a way to toggle proxy with env settings SOCKS_DISABLE
- replace lower-level `adapter.get_connection()` with `adapter.proxy_manager_for(self.socks_proxy)` which returns a proxy manager which determines appropriate url to use with socks proxy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Loading https://check.torproject.org/ over SOCKS resulted in a 500 error, because the proxy was incorrectly sending `GET https://check.torproject.org/` instead of `GET /`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
