### PR TITLE
Tweak query page to be responsive

### DIFF
--- a/pywb/static/query.js
+++ b/pywb/static/query.js
@@ -391,7 +391,7 @@ RenderCalendar.prototype.createContainers = function() {
         // years column and initial display structure
         {
           tag: 'div',
-          className: 'col-2 pr-1 pl-1 h-100',
+          className: 'col-12 col-sm-2 pr-1 pl-1 h-100',
           child: {
             tag: 'div',
             className: 'list-group h-100 auto-overflow',
@@ -405,7 +405,7 @@ RenderCalendar.prototype.createContainers = function() {
         // months initial structure
         {
           tag: 'div',
-          className: 'col-2 pr-1 pl-1 h-100',
+          className: 'col-12 mt-2 col-sm-2 mt-sm-0 pr-1 pl-1 h-100',
           child: {
             tag: 'div',
             className: 'tab-content h-100',
@@ -418,7 +418,7 @@ RenderCalendar.prototype.createContainers = function() {
         // days initial structure
         {
           tag: 'div',
-          className: 'col-8 pl-1 h-100',
+          className: 'col-12 mt-3 mb-3 pr-1 mt-sm-0 mb-sm-0 pr-sm-0 col-sm-8 pl-1 h-100',
           child: {
             tag: 'div',
             className: 'tab-content h-100',

--- a/pywb/templates/base.html
+++ b/pywb/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="{{ env.pywb_lang | default('en') }}">
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8;charset=utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>{% block title %}{% endblock %}</title>
 

--- a/pywb/templates/query.html
+++ b/pywb/templates/query.html
@@ -15,11 +15,11 @@
 {% block body %}
 <div class="container-fluid">
     <div class="row justify-content-center">
-        <h4 class="display-4 p-0">{{ _('Search Results') }}</h4>
+        <h4 class="display-4 text-center text-sm-left p-0">{{ _('Search Results') }}</h4>
     </div>
 </div>
 <div class="container">
-    <div class="row justify-content-center mt-1" id="display-query-type-info"></div>
+    <div class="row justify-content-center text-center text-sm-left mt-1" id="display-query-type-info"></div>
 </div>
 <div class="container mt-3 q-display" id="captures"></div>
 <script>


### PR DESCRIPTION

## Description
Adjusts bootstrap responsive classes on query page. Now elements stack for small/mobile viewports.

## Motivation and Context
Currently the page does not respond to browser window size.

## Screenshots (if appropriate):
![Screen Shot 2019-11-01 at 6 14 52 PM](https://user-images.githubusercontent.com/216952/68059631-861f2d80-fcd3-11e9-850f-adf2e93550bf.png)
![Screen Shot 2019-11-01 at 5 05 12 PM](https://user-images.githubusercontent.com/216952/68059640-90d9c280-fcd3-11e9-97a0-19e15c7de654.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
