### PR TITLE
config limit: add query_limit config options to specify optional limi…

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -92,6 +92,7 @@ class FrontEndApp(object):
         self.static_handler = StaticHandler(static_path)
 
         self.cdx_api_endpoint = config.get('cdx_api_endpoint', '/cdx')
+        self.query_limit = config.get('query_limit')
 
         upstream_paths = self.get_upstream_paths(self.warcserver_server.port)
 
@@ -354,6 +355,10 @@ class FrontEndApp(object):
         if environ.get('QUERY_STRING'):
             cdx_url += '&' if '?' in cdx_url else '?'
             cdx_url += environ.get('QUERY_STRING')
+
+        if self.query_limit:
+            cdx_url += '&' if '?' in cdx_url else '?'
+            cdx_url += 'limit=' + str(self.query_limit)
 
         try:
             res = requests.get(cdx_url, stream=True)

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -713,6 +713,9 @@ class RewriterApp(object):
         if 'memento_format' in kwargs:
             params['memento_format'] = kwargs['memento_format']
 
+        if 'limit' in kwargs:
+            params['limit'] = kwargs['limit']
+
         upstream_url = self.get_upstream_url(wb_url, kwargs, params)
         upstream_url = upstream_url.replace('/resource/postreq', '/index')
 

--- a/tests/config_test_redirect_classic.yaml
+++ b/tests/config_test_redirect_classic.yaml
@@ -17,3 +17,5 @@ enable_memento: true
 enable_prefer: true
 
 debug: true
+
+query_limit: 10

--- a/tests/test_redirect_classic.py
+++ b/tests/test_redirect_classic.py
@@ -74,4 +74,8 @@ class TestRedirectClassic(BaseConfigTest):
         resp = self.get('/live/{0}http://example.com/?test=test', fmod_slash)
         assert resp.status_int == 200
 
+    def test_replay_limit_cdx(self):
+        resp = self.testapp.get('/pywb/cdx?url=http://www.iana.org/*&output=json')
+        assert resp.content_type == 'text/x-ndjson'
+        assert len(resp.text.rstrip().split('\n')) == 10
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Add option to limit number of results in url queries (exact or prefix)
via config `query_limit` option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Requested as part of ukwa/ukwa-pywb#49

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
