### PR TITLE
Restrict POST query size

### DIFF
--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -10,7 +10,6 @@ from io import BytesIO
 
 import base64
 import cgi
-import sys
 
 
 #=============================================================================

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -10,6 +10,7 @@ from io import BytesIO
 
 import base64
 import cgi
+import sys
 
 
 #=============================================================================
@@ -181,6 +182,8 @@ class POSTInputRequest(DirectWSGIInputRequest):
 
 # ============================================================================
 class MethodQueryCanonicalizer(object):
+    MAX_POST_SIZE = 16384
+
     def __init__(self, method, mime, length, stream,
                        buffered_stream=None,
                        environ=None):
@@ -210,7 +213,9 @@ class MethodQueryCanonicalizer(object):
         if length <= 0:
             return
 
-        query = b''
+        # max POST query allowed, for size considerations, only read upto this size
+        length = min(length, self.MAX_POST_SIZE)
+        query = []
 
         while length > 0:
             buff = stream.read(length)
@@ -219,7 +224,9 @@ class MethodQueryCanonicalizer(object):
             if not buff:
                 break
 
-            query += buff
+            query.append(buff)
+
+        query = b''.join(query)
 
         if buffered_stream:
             buffered_stream.write(query)
@@ -236,7 +243,8 @@ class MethodQueryCanonicalizer(object):
 
         if mime.startswith('application/x-www-form-urlencoded'):
             try:
-                query = to_native_str(query.decode('utf-8'))
+                if PY3:
+                    query = query.decode('utf-8')
                 query = unquote_plus(query)
             except UnicodeDecodeError:
                 query = handle_binary(query)

--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -243,8 +243,7 @@ class MethodQueryCanonicalizer(object):
 
         if mime.startswith('application/x-www-form-urlencoded'):
             try:
-                if PY3:
-                    query = query.decode('utf-8')
+                query = to_native_str(query.decode('utf-8'))
                 query = unquote_plus(query)
             except UnicodeDecodeError:
                 query = handle_binary(query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Current indexing reads an entire POST request, which can be quite large, and attempts to append to urlkey query.  Now restrict reading POST request to 16384, skip reading the remainder.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Many sites include large logs in POST during regular browsing (eg. instagram).
Indexing can get quite slow if reading the entire POST request, and is unnecessary.
Supersedes #482, truncating POST request at read time.
It is unlikely that such large queries would ever match exactly and only ever match via fuzzy lookup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
