### PR TITLE
apply fuzzy match if url prefix and regex match

### DIFF
--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -84,7 +84,7 @@ class FuzzyMatcher(object):
                 m = rule.regex.search(urlkey)
                 groups = m and m.groups()
 
-            if not groups:
+            if groups is None:
                 continue
 
             matched_rule = rule
@@ -99,7 +99,7 @@ class FuzzyMatcher(object):
 
         # support matching w/o query if no additional filters
         # don't include trailing '?' if no filters and replace_after '?'
-        no_filters = (filters == {'urlkey:'}) and (matched_rule.replace_after == '?')
+        no_filters = (not filters or filters == {'urlkey:'}) and (matched_rule.replace_after == '?')
 
         inx = url.find(matched_rule.replace_after)
         if inx > 0:


### PR DESCRIPTION
 even if no groups are captured by the regex

As we discussed on slack.
```
nlevitt 3:12 PM
hey dude, i have a question about the fuzzy match rules

https://github.com/webrecorder/pywb/blob/5f938e68797/pywb/warcserver/index/fuzzymatcher.py#L70 (edited) 
if i’m reading the code right, if a url prefix matches and the regex matches, but there are no matching groups, then the fuzzy match rule does not apply
ikreymer 3:14 PM
hey, yeah, this could probably benefit from additional comments..
nlevitt 3:15 PM
i’m wondering, if the regex matches, why not consider that a match… and if there are no matching groups, then you just don’t have any urlkey: filters
this came up because some of our fuzzy match rules from java wayback have regexes with no capturing group parens
and i didn’t think about this case when i migrated them over
for example
 782     # <!-- for https://webarchive.jira.com/browse/AITFIVE-4477 -->
 783     # <bean class="org.archive.archiveit.url.ArchiveItExtractRule">             
 784     #   <property name="startsWith" value="com,tumblr,media"/>                  
 785     #   <property name="regex" value="[&amp;?].*r=[\d.]+.*"/>                   
 786     # </bean>                                                                   
 787     #                                                                           
 788     # <!-- for https://webarchive.jira.com/browse/AITFIVE-4477 -->              
 789     # <bean class="org.archive.archiveit.url.ArchiveItExtractRule">             
 790     #   <property name="startsWith" value="com,trainwreckmovie)/img/sounds"/>   
 791     #   <property name="regex" value="[&amp;?].*r=[\d.]+.*"/>                   
 792     # </bean>                                                                   
 793     - url_prefix:                                                               
 794       - com,tumblr,media                                                        
 795       - com,trainwreckmovie)/img/sounds                                         
 796       fuzzy_lookup: '[&?].*r=[\d.]+.*'                                          
i think i can make it work just by adding an empty capturing group () somewhere in that regex
ikreymer 3:20 PM
trying to remember how it all works.. hm
yes, i suppose that would work if if not groups did if groups is None
that might have been an oversight.., or maybe i specifically wanted it to have at least one capture group..
right, so w/o capture group the first prefix result will be selected
nlevitt 3:25 PM
“first prefix result will be selected” — not 100% sure what you mean by that
ikreymer 3:30 PM
oh i just mean the first result from the prefix query, w/o any filters.. i guess its the same with filters, so, yeah that makes sense :slightly_smiling_face:
nlevitt 3:30 PM
ah ok
so far you haven’t been able to think of anything that would break if you changed if not groups to if groups is None ? :slightly_smiling_face:
ikreymer 3:36 PM
right, yeah
yeah, i think that should be fine, since rx is still matched, just no groups
nlevitt 3:38 PM
cool
is that a change you’d like to make? i’d rather not deviate from pywb here
and can work around it with configuration
but making the change looks like the best solution from my perspective
ikreymer 3:41 PM
yeah, i can make that change in pywb
```
