### PR TITLE
Misc Fixes for RC5

### DIFF
--- a/pywb/static/default_banner.js
+++ b/pywb/static/default_banner.js
@@ -306,8 +306,8 @@ This file is part of pywb, https://github.com/webrecorder/pywb
   // all banners will expose themselves by adding themselves as WBBanner on window
   window.WBBanner = new DefaultBanner();
 
-  // if not in top-frame (replay frame/non-framed/proxy), init immeidately
-  if (window.wbinfo && !window.wbinfo.is_frame) {
+  // if wbinfo.url is set and not-framed, init banner in content frame
+  if (window.wbinfo && window.wbinfo.url && !window.wbinfo.is_framed) {
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", function() {
         window.WBBanner.init();

--- a/pywb/static/default_banner.js
+++ b/pywb/static/default_banner.js
@@ -306,8 +306,8 @@ This file is part of pywb, https://github.com/webrecorder/pywb
   // all banners will expose themselves by adding themselves as WBBanner on window
   window.WBBanner = new DefaultBanner();
 
-  // if in replay frame, init immediately
-  if (window.wbinfo) {
+  // if not in top-frame (replay frame/non-framed/proxy), init immeidately
+  if (window.wbinfo && !window.wbinfo.is_frame) {
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", function() {
         window.WBBanner.init();

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.4.0rc4'
+__version__ = '2.4.0-rc5'
 
 if __name__ == '__main__':
     print(__version__)

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -139,18 +139,19 @@ class BaseLoader(object):
         request_url = request_url.split('://', 1)[-1].rstrip('/')
 
         self_redir = False
+        orig_key = params.get('sr-urlkey') or cdx['urlkey']
 
         if request_url == location_url:
             self_redir = True
-        elif params.get('sr-urlkey'):
-            # if new location canonicalized matches old key, also self-redirect
-            if canonicalize(location_url) == params.get('sr-urlkey'):
-                self_redir = True
+
+        # if new location canonicalized matches old key, also self-redirect
+        elif canonicalize(location_url) == orig_key:
+            self_redir = True
 
         if self_redir:
             msg = 'Self Redirect {0} -> {1}'
             msg = msg.format(request_url, location_url)
-            params['sr-urlkey'] = cdx['urlkey']
+            params['sr-urlkey'] = orig_key
             raise LiveResourceException(msg)
 
     @staticmethod
@@ -267,6 +268,9 @@ class LiveWebLoader(BaseLoader):
             self.socks_proxy = None
 
     def load_resource(self, cdx, params):
+        if cdx.get('filename') and cdx.get('offset') is not None:
+            return None
+
         load_url = cdx.get('load_url')
         if not load_url:
             return None

--- a/pywb/warcserver/test/test_handlers.py
+++ b/pywb/warcserver/test/test_handlers.py
@@ -220,8 +220,8 @@ class TestBaseWarcServer(HttpBinLiveTests, MementoOverrideTests, FakeRedisTests,
         buff = BytesIO(resp.body)
         record = ArcWarcRecordLoader().parse_record_stream(buff, no_record_parse=False)
         print(record.http_headers)
-        assert record.http_headers.get_statuscode() == '302'
-        assert record.http_headers.get_header('Location') == 'https://www.iana.org/'
+        assert record.http_headers.get_statuscode() == '200'
+        #assert record.http_headers.get_header('Location') == 'https://www.iana.org/'
 
     @patch('pywb.warcserver.index.indexsource.MementoIndexSource.get_timegate_links', MementoOverrideTests.mock_link_header('select_live'))
     def test_agg_select_live(self):


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Misc fixes for pywb 2.4.0-rc5

Fix to previous banner fix #531 to quickly (hopefully addresses issue mentioned in #527)
Fix `cdx+` query: don't use live loading if WARC file/offset are set
Self-Redirects Improvements: filter out www -> www2. redirects as self-redirects if canonicalized to same key.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Attempting to fix ukwa/ukwa-pywb#53 and issue mentioned in #527 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
