### PR TITLE
proxy mode: respect settings when started from cli

### DIFF
--- a/pywb/warcserver/warcserver.py
+++ b/pywb/warcserver/warcserver.py
@@ -54,6 +54,8 @@ class WarcServer(BaseWarcServer):
         if custom_config:
             if 'collections' in custom_config and 'collections' in config:
                 custom_config['collections'].update(config['collections'])
+            if 'proxy' in custom_config and 'proxy' in config:
+                custom_config['proxy'].update(config['proxy'])
             config.update(custom_config)
 
         super(WarcServer, self).__init__(debug=config.get('debug', False))


### PR DESCRIPTION
If you configure some proxy settings like enable_content_rewrite in config.yaml, when you run wayback --proxy mycollection it does not work.

This is because the entire proxy section is replaced by the extra config (custom_config) generated according to the command line arguments in cli.py.

This fix makes the section values to be replaced, but not the entire section. So the existing values won't be removed.

Another approach would be to add command line arguments for the rest of the available settings  like --proxy-enable-content-rewrite, etc... I don't know which is preferred in this project.