### PR TITLE
proxy mode: don't rewrite xml for ajax requests. Support python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 dist: xenial
 
@@ -39,6 +40,7 @@ after_success:
 matrix:
   allow_failures:
     - env: WR_TEST=yes
+    - python: "2.7"
 
   exclude:
     - env: WR_TEST=yes

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -2,6 +2,6 @@ certauth
 youtube-dl
 boto3
 uwsgi
-git+https://github.com/esnme/ultrajson.git
+ujson
 pysocks
 lxml

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -822,6 +822,12 @@ class RewriterApp(object):
         if value and value.lower() == 'xmlhttprequest':
             return True
 
+        # if Chrome Sec-Fetch-Mode is set and is not 'navigate', then this is likely
+        # a fetch / ajax request
+        sec_fetch_mode = environ.get('HTTP_SEC_FETCH_MODE')
+        if sec_fetch_mode and sec_fetch_mode != 'navigate':
+            return True
+
         return False
 
     def is_preflight(self, environ):

--- a/pywb/rewrite/html_insert_rewriter.py
+++ b/pywb/rewrite/html_insert_rewriter.py
@@ -9,13 +9,22 @@ class HTMLInsertOnlyRewriter(StreamingRewriter):
     """
     NOT_HEAD_REGEX = re.compile(r'(<\s*\b)(?!(html|head))', re.I)
 
+    XML_HEADER = re.compile(r'<\?xml.*\?>')
+
     def __init__(self, url_rewriter, **kwargs):
         super(HTMLInsertOnlyRewriter, self).__init__(url_rewriter, False)
         self.head_insert = kwargs['head_insert']
 
         self.done = False
+        self.first = True
 
     def rewrite(self, string):
+        if self.first:
+            if self.url_rewriter.rewrite_opts.get('is_ajax') and self.XML_HEADER.search(string):
+                self.done = True
+
+            self.first = False
+
         if self.done:
             return string
 

--- a/pywb/rewrite/test/test_html_insert_rewriter.py
+++ b/pywb/rewrite/test/test_html_insert_rewriter.py
@@ -16,13 +16,23 @@ r'''
 
 >>> parse('<head></head>text')
 '<head></head>text<!--Insert-->'
+
+>>> parse('<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<html xmlns="http://www.w3.org/1999/xhtml"><body></body></html>')
+'<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<html xmlns="http://www.w3.org/1999/xhtml"><!--Insert--><body></body></html>'
+
+# ajax leave unchanged?
+>>> parse('<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<html xmlns="http://www.w3.org/1999/xhtml"><body></body></html>', is_ajax=True)
+'<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<html xmlns="http://www.w3.org/1999/xhtml"><body></body></html>'
 '''
 
 from pywb.rewrite.url_rewriter import UrlRewriter
 from pywb.rewrite.html_insert_rewriter import HTMLInsertOnlyRewriter
 
-def parse(html_text):
+def parse(html_text, is_ajax=False):
     urlrewriter = UrlRewriter('20131226101010/https://example.com/some/path.html', '/web/')
+
+    if is_ajax:
+        urlrewriter.rewrite_opts['is_ajax'] = True
 
     rewriter = HTMLInsertOnlyRewriter(urlrewriter, head_insert='<!--Insert-->')
 

--- a/pywb/utils/loaders.py
+++ b/pywb/utils/loaders.py
@@ -7,6 +7,7 @@ local and remote access
 
 import os
 import hmac
+import hashlib
 import requests
 import yaml
 
@@ -485,7 +486,7 @@ class HMACCookieMaker(object):
         else:
             msg = expire
 
-        hmacdigest = hmac.new(self.key.encode('utf-8'), msg.encode('utf-8'))
+        hmacdigest = hmac.new(self.key.encode('utf-8'), msg.encode('utf-8'), digestmod=hashlib.md5)
         hexdigest = hmacdigest.hexdigest()
 
         if extra_id:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
In proxy mode, don't inject header for ajax requests. Detect via Sec-Fetch-Mode header,
since not adding custom pywb headers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Fixes proxy mode replay of fulcrum sites, eg. https://www.fulcrum.org/epubs/t722h883s?locale=en#/6/2[Cover1]!/4/4/1:0

Minor fix / CI support for py3.8

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
