### PR TITLE
Fix link in access-control docs to use RST instead of MD syntax

### DIFF
--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -49,7 +49,7 @@ Access Error Messages
 
 The special error code 451 is used to indicate that a resource has been blocked (access setting ``block``)
 
-The [error.html](https://github.com/webrecorder/pywb/blob/master/pywb/templates/error.html) template contains a special message for this access and can be customized further.
+The `error.html <https://github.com/webrecorder/pywb/blob/master/pywb/templates/error.html>`_ template contains a special message for this access and can be customized further.
 
 By design, resources that are ``exclude``-ed simply appear as 404 not found and no special error is provided.
 


### PR DESCRIPTION
## Description
In the access control documentation, there exists a link to an external resource. This link is written in markdown (MD) format whereas the document itself it reStructureText (RST). This PR updates the link to use RST-style syntax and the inline formatting used in other pywb documentation (cf. links at the end and a keyword used).

## Motivation and Context
I noticed this issue when reviewing the documentation at https://pywb.readthedocs.io/en/latest/manual/access-control.html . The link there exposed both the URI destination as well as the text to be linked without appropriately encoding the link on render.

## Screenshots (if appropriate):
![Screen Shot 2020-06-15 at 10 31 46 AM](https://user-images.githubusercontent.com/2514780/84669975-79161e00-aef3-11ea-8224-8f291ed8e6be.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
