### PR TITLE
docs: Fix incorrect example

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -174,7 +174,7 @@ done by directly recording into your pywb collection:
 2. Run: ``wayback --record --live -a --auto-interval 10``
 3. Point your browser to ``http://localhost:8080/my-web-archive/record/<url>``
 
-For example, to record ``http://example.com/``, visit ``http://localhost:8080/my-web-archive/record/<url>``
+For example, to record ``http://example.com/``, visit ``http://localhost:8080/my-web-archive/record/http://example.com/``
 
 In this configuration, the indexing happens every 10 seconds.. After 10 seconds, the recorded url will be accessible for replay, eg:
 ``http://localhost:8080/my-web-archive/http://example.com/``


### PR DESCRIPTION
The example in the current docs is incorrect - the section about [Using pywb recorder](https://pywb.readthedocs.io/en/latest/manual/usage.html#using-pywb-recorder) currently reads:

> For example, to record `http://example.com/`, visit `http://localhost:8080/my-web-archive/record/<url>`

This PR simply replaces `<url>` with `http://example.com/`, as (probably) intended by the writers of the documentation. I thus discarded the rest of the PR template as it does not apply to such a small change (I would assume).