### PR TITLE
Add support for verifying ssl certificates 

### DIFF
--- a/docs/manual/configuring.rst
+++ b/docs/manual/configuring.rst
@@ -553,3 +553,15 @@ To enable the previous behavior, add to config::
   enable_flash_video_rewrite: true
 
 The system may be revamped in the future and enabled by default, but for now, it is provided "as-is" for compatibility reasons.
+
+Verify SSL-Certificates
+-----------------------
+
+By default, SSL-Certificates of websites are not verified. To enable verification, add the following to the config::
+
+  certificates:
+    cert_reqs: 'CERT_REQUIRED'
+    ca_cert_dir: '/etc/ssl/certs'
+
+``ca_cert_dir`` can optionally point to a directory containing the CA certificates that you trust. Most linux distributions provide CA certificates via a package called ``ca-certificates``.
+If omitted, the default system CA used by Python is used.

--- a/pywb/warcserver/http.py
+++ b/pywb/warcserver/http.py
@@ -17,8 +17,10 @@ class PywbHttpAdapter(HTTPAdapter):
     until a better solution is found
     """
 
-    # todo: allow configuring this later?
-    cert_reqs = 'CERT_NONE'
+    def __init__(self, cert_reqs='CERT_NONE', ca_cert_dir=None, **init_kwargs):
+        self.cert_reqs = cert_reqs
+        self.ca_cert_dir = ca_cert_dir
+        return super(PywbHttpAdapter, self).__init__(**init_kwargs)
 
     def init_poolmanager(
         self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs
@@ -32,11 +34,13 @@ class PywbHttpAdapter(HTTPAdapter):
             block=block,
             strict=True,
             cert_reqs=self.cert_reqs,
+            ca_cert_dir=self.ca_cert_dir,
             **pool_kwargs
         )
 
     def proxy_manager_for(self, proxy, **proxy_kwargs):
         proxy_kwargs['cert_reqs'] = self.cert_reqs
+        proxy_kwargs['ca_cert_dir'] = self.ca_cert_dir
         return super(PywbHttpAdapter, self).proxy_manager_for(proxy, **proxy_kwargs)
 
 

--- a/tests/config_test_cert_req.yaml
+++ b/tests/config_test_cert_req.yaml
@@ -1,0 +1,7 @@
+debug: true
+
+collections:
+    live: $live
+
+certificates:
+    cert_reqs: 'CERT_REQUIRED'

--- a/tests/test_cert_req.py
+++ b/tests/test_cert_req.py
@@ -1,0 +1,17 @@
+from .base_config_test import BaseConfigTest
+
+# ============================================================================
+class TestCertReq(BaseConfigTest):
+    @classmethod
+    def setup_class(cls):
+        super(TestCertReq, cls).setup_class('config_test_cert_req.yaml')
+
+    def test_expired_cert(self):
+        resp = self.testapp.get('/live/mp_/https://expired.badssl.com/', status='*')
+
+        assert resp.status_int == 400
+
+    def test_good_cert(self):
+        resp = self.testapp.get('/live/mp_/https://www.google.com/', status='*')
+
+        assert resp.status_int >= 200 and resp.status_int < 400


### PR DESCRIPTION
## Description
For Security reasons it may be desirable to reject invalid certificates. This adds configuration
options to configure this.

Fixes: #594

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
