### PR TITLE
Handle Content-Type multipart/form-data without boundary

### DIFF
--- a/pywb/warcserver/inputrequest.py
+++ b/pywb/warcserver/inputrequest.py
@@ -259,13 +259,17 @@ class MethodQueryCanonicalizer(object):
             if PY3:
                 args['encoding'] = 'utf-8'
 
-            data = cgi.FieldStorage(**args)
+            try:
+                data = cgi.FieldStorage(**args)
+            except ValueError:
+                # Content-Type multipart/form-data may lack "boundary" info
+                query = handle_binary(query)
+            else:
+                values = []
+                for item in data.list:
+                    values.append((item.name, item.value))
 
-            values = []
-            for item in data.list:
-                values.append((item.name, item.value))
-
-            query = urlencode(values, True)
+                query = urlencode(values, True)
 
         elif mime.startswith('application/x-amf'):
             query = self.amf_parse(query, environ)

--- a/pywb/warcserver/test/test_inputreq.py
+++ b/pywb/warcserver/test/test_inputreq.py
@@ -143,6 +143,13 @@ class TestPostQueryExtract(object):
         #base64 encoded data
         assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw='
 
+    def test_post_extract_no_boundary_in_multipart_form_mimetype(self):
+        mq = MethodQueryCanonicalizer('POST', 'multipart/form-data',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+
+
     def test_options(self):
         mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())
         assert mq.append_query('http://example.com/') == 'http://example.com/?__pywb_method=options'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Catches `ValueError` on a multipart/form-data mime when "boundary" is missing, and handles it in the same way as an earlier condition for 'application/x-www-form-urlencoded' erroring on `UnicodeDecodeError`.  When I try to run the tests with `python setup.py test`, test_proxy.py tests fail, but this seems unrelated and is the same when I run them on the `master` branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Fix for #598 to handle a `ValueError` on a multipart/form-data mime when "boundary" is missing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
