### PR TITLE
Catch uWSGI TypeError for invalid headers

### DIFF
--- a/pywb/apps/wbrequestresponse.py
+++ b/pywb/apps/wbrequestresponse.py
@@ -164,7 +164,7 @@ class WbResponse(object):
         try:
             start_response(self.status_headers.statusline,
                            self.status_headers.headers)
-        except UnicodeError:
+        except (UnicodeError, TypeError):
             self.try_fix_errors()
             start_response(self.status_headers.statusline,
                            self.status_headers.headers)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Catch TypeError thrown by uWSGI in addition to UnicodeError

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The fix for invalid headers merged with webrecorder/pywb#536 seems not to be working with Docker/uWSGI/Python3. Looking at https://github.com/unbit/uwsgi/blob/master/plugins/python/wsgi_headers.c#L140, uWSGI is throwing a TypeError, not a UnicodeError. However, UnicodeError is correct when not using uWSGI (e.g. run with cli.py).

Catching the TypeError solves the replay problem also when running pywb with Docker/uWSGI/Python3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
