### PR TITLE
Fix default banner css namespacing

### DIFF
--- a/pywb/static/default_banner.css
+++ b/pywb/static/default_banner.css
@@ -159,7 +159,7 @@
     overflow: scroll;
 }
 
-.mobile {
+._wb_mobile {
     display: none;
 }
 
@@ -170,11 +170,11 @@
         height: 26px;
         margin-left: 10px;
     }
-    #_wb_frame_top_banner ._wb_linked_logo img:not(.mobile)
+    #_wb_frame_top_banner ._wb_linked_logo img:not(._wb_mobile)
     {
         display: none;
     }
-    #_wb_frame_top_banner .mobile
+    #_wb_frame_top_banner ._wb_mobile
     {
         display: block;
     }
@@ -184,7 +184,7 @@
         margin: 0 5px;
     }
 
-    #_wb_frame_top_banner .no-mobile
+    #_wb_frame_top_banner ._wb_no-mobile
     {
         display: none;
     }

--- a/pywb/static/default_banner.js
+++ b/pywb/static/default_banner.js
@@ -15,7 +15,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
 
     You should have received a copy of the GNU General Public License
     along with pywb.  If not, see <http://www.gnu.org/licenses/>.
-   
+
 */
 
 // Creates the default pywb banner.
@@ -159,7 +159,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
 
       var logoContents = "";
       logoContents += "<img src='" + window.banner_info.logoImg + "' alt='" + window.banner_info.logoAlt + "'>";
-      logoContents += "<img src='" + window.banner_info.logoImg + "' class='mobile' alt='" + window.banner_info.logoAlt + "'>";
+      logoContents += "<img src='" + window.banner_info.logoImg + "' class='_wb_mobile' alt='" + window.banner_info.logoAlt + "'>";
 
       logo.innerHTML = logoContents;
       this.banner.appendChild(logo);
@@ -178,7 +178,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
     var calendarLink = document.createElement("a");
     calendarLink.setAttribute("id", "calendarLink");
     calendarLink.setAttribute("href", "#");
-    calendarLink.innerHTML = "<img src='" + calendarImg + "' alt='" + window.banner_info.calendarAlt + "'><span class='no-mobile'>&nbsp;" +window.banner_info.calendarLabel + "</span>";
+    calendarLink.innerHTML = "<img src='" + calendarImg + "' alt='" + window.banner_info.calendarAlt + "'><span class='_wb_no-mobile'>&nbsp;" +window.banner_info.calendarLabel + "</span>";
     ancillaryLinks.appendChild(calendarLink);
     this.calendarLink = calendarLink;
 
@@ -187,7 +187,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
       var languages = document.createElement("div");
 
       var label = document.createElement("span");
-      label.setAttribute("class", "no-mobile");
+      label.setAttribute("class", "_wb_no-mobile");
       label.appendChild(document.createTextNode(window.banner_info.choiceLabel + " "));
       languages.appendChild(label);
 


### PR DESCRIPTION
## Description
Added prefix/namespace to css class "mobile" (new: "_wb_mobile") in the default files. 

## Motivation and Context
As the banner CSS may get injected, this can lead to conflicts with the replayed site if a "mobile" class is used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
