### PR TITLE
CDX sorting: Default list sort is more efficient

### DIFF
--- a/pywb/indexer/cdxindexer.py
+++ b/pywb/indexer/cdxindexer.py
@@ -27,7 +27,6 @@ except ImportError:  # pragma: no cover
 
 
 from argparse import ArgumentParser, RawTextHelpFormatter
-from bisect import insort
 
 from six import StringIO
 
@@ -167,9 +166,10 @@ class SortedCDXWriter(BaseCDXWriter):
         super(SortedCDXWriter, self).write(entry, filename)
         line = self.out.getvalue()
         if line:
-            insort(self.sortlist, line)
+            self.sortlist.append(line)
 
     def __exit__(self, *args):
+        self.sortlist.sort()
         self.actual_out.write(''.join(self.sortlist))
         return False
 


### PR DESCRIPTION
## Description
As mentioned in #608 and explained in: https://stackoverflow.com/a/53023435
it turns out the CDX sorting that pywb uses is less efficient, than the default list sort.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

In fact, it appears to be that the current sorting ends up being O(n^2) instead of O(n * log n), which would cause significant perf issues for larger indexes.

This switches to just aggregating all cdx, and sorting at the end.

Sometimes the simpler solution is the correct one!
