### PR TITLE
Fix dedup_index_url configuration option

### DIFF
--- a/pywb/warcserver/warcserver.py
+++ b/pywb/warcserver/warcserver.py
@@ -78,7 +78,7 @@ class WarcServer(BaseWarcServer):
 
         recorder_config = self.config.get('recorder') or {}
         if isinstance(recorder_config, dict) and recorder_config.get('dedup_policy'):
-            self.dedup_index_url = self.config.get('dedup_index_url', WarcServer.DEFAULT_DEDUP_URL)
+            self.dedup_index_url = recorder_config.get('dedup_index_url', WarcServer.DEFAULT_DEDUP_URL)
             if self.dedup_index_url and not self.dedup_index_url.startswith('redis://'):
                 raise Exception("The dedup_index_url must start with \"redis://\". Only Redis-based dedup index is supported at this time.")
         else:


### PR DESCRIPTION
The 'dedup_index_url' configuration option should be inside the
'recorder' section.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
