### PR TITLE
IndexHandler: backward-compatibility for `fl` (fields) param

### DIFF
--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -80,6 +80,8 @@ class IndexHandler(object):
 
         output = params.get('output', self.DEF_OUTPUT)
         fields = params.get('fields')
+        if not fields:
+            fields = params.get('fl')
 
         if fields and isinstance(fields, str):
             fields = fields.split(',')


### PR DESCRIPTION
## Description
While CDXQuery supports the old query parameter `fl` ([query.py#L88](/webrecorder/pywb/blob/78a9888b4673b33cfa263b5ced684a9c855331d5/pywb/warcserver/index/query.py#L88)), the class IndexHandler does not,

## Description
The PR add backward-compatibility support for the query parameter `fl` (in addition to the param `fields`).

## Motivation and Context
The change is part of an effort to upgrade [Common Crawl's CDX server](https://index.commoncrawl.org/) to the recent version of PyWB while ensuring 100% API compatibility (see commoncrawl/cc-index-server#8). Teaching the users a new API and upgrading all clients in the wild seems impossible as there are too many.