### PR TITLE
Warcserver / CDXJ API: properly handle unsupported output formats

### DIFF
--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -84,7 +84,7 @@ class IndexHandler(object):
         if fields and isinstance(fields, str):
             fields = fields.split(',')
 
-        handler = self.OUTPUTS.get(output, fields)
+        handler = self.OUTPUTS.get(output)
         if not handler:
             errs = dict(last_exc=BadRequestException('output={0} not supported'.format(output)))
             return None, None, errs

--- a/tests/test_cdx_server_app.py
+++ b/tests/test_cdx_server_app.py
@@ -287,5 +287,13 @@ class TestCDXApp(BaseTestClass):
         for i in range(len(cdxes) - 1):
             assert cdxes[i]['timestamp'] >= cdxes[i + 1]['timestamp']
 
+    def test_error_unknown_output_format(self):
+        """test unknown output format in combination with a list of output fields"""
+        resp = self.query('http://www.iana.org/_css/2013.1/print.css',
+                          is_error=True,
+                          fields='urlkey,timestamp,status',
+                          output='foo')
+        assert resp.status_code == 400
+        assert resp.json == {'message': 'output=foo not supported'}
 
 


### PR DESCRIPTION
## Description

Warcserver throws a "TypeError" (message: `'list' object is not callable`) when
- the [output format](https://pywb.readthedocs.io/en/latest/manual/cdxserver_api.html#output), passed via the CDXJ API param `output`, is not supported
- and, as a site condition, the param `fields` requests a list of output fields

The expected behavior is to throw a BadRequestException and report the unsupported output format.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and previously successful tests pass.