### PR TITLE
FrontendApp: forward HTTP status of CDX backend

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -404,10 +404,12 @@ class FrontEndApp(object):
         try:
             res = requests.get(cdx_url, stream=True)
 
+            status_line = '{} {}'.format(res.status_code, res.reason)
             content_type = res.headers.get('Content-Type')
 
             return WbResponse.bin_stream(StreamIter(res.raw),
-                                         content_type=content_type)
+                                         content_type=content_type,
+                                         status=status_line)
 
         except Exception as e:
             return WbResponse.text_response('Error: ' + str(e), status='400 Bad Request')

--- a/pywb/warcserver/basewarcserver.py
+++ b/pywb/warcserver/basewarcserver.py
@@ -141,6 +141,9 @@ class BaseWarcServer(object):
             out_headers['ResErrors'] = res[0]
             message = message.encode('utf-8')
 
-        message = str(status) + ' ' + message
+        if isinstance(status, str):
+            message = status
+        else:
+            message = str(status) + ' ' + message
         start_response(message, list(out_headers.items()))
         return res


### PR DESCRIPTION
## Description

The patch makes FrontendApp forward the HTTP status of the CDX backend, so that clients can handle errors properly.

## Motivation and Context

If the CDX backend fails to process a query, the FrontendApp still responds with HTTP status `200 OK`. The (error) status (eg. "400 Bad request", "404 Not found", etc.) should be passed forward to the client.

A clear HTTP error simplifies the processing of the CDX results in the client. The fix also ensures that the CDXJ API is compatibility with the behavior of the API in PyWB 0.33.2.

One example to reproduce the issue:
- call the CDXJ API with an unsupported output format (`...&output=foo`)
- the FrontendApp responds with HTTP status 200. Only the response body indicates that there was actually an error and shows the reason `{"message": "output=foo not supported"}`

With the patch applied the response status will be `400 Bad Request output=foo not supported`, the response body is unchanged.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and previously successful tests passed.
