### PR TITLE
IndexHandler: report BadRequestException as error

### DIFF
--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -92,7 +92,11 @@ class IndexHandler(object):
             errs = dict(last_exc=BadRequestException('output={0} not supported'.format(output)))
             return None, None, errs
 
-        cdx_iter, errs = self._load_index_source(params)
+        cdx_iter = None
+        try:
+            cdx_iter, errs = self._load_index_source(params)
+        except BadRequestException as e:
+            errs = dict(last_exc=e)
         if not cdx_iter:
             return None, None, errs
 

--- a/tests/test_cdx_server_app.py
+++ b/tests/test_cdx_server_app.py
@@ -296,4 +296,12 @@ class TestCDXApp(BaseTestClass):
         assert resp.status_code == 400
         assert resp.json == {'message': 'output=foo not supported'}
 
+    def test_error_unknown_match_type(self):
+        """test unknown/unsupported matchType"""
+        resp = self.query('http://www.iana.org/_css/2013.1/print.css',
+                          is_error=True,
+                          fields='urlkey,timestamp,status',
+                          matchType='foo')
+        assert resp.status_code == 400
+        assert resp.json == {'message': 'Invalid match_type: foo'}
 


### PR DESCRIPTION
When the CDXJ API is queried with an unknown `matchType` parameter, the failure is reported as "Internal server error" (HTTP status 500).

The patch fixes the IndexHandler to catch the BadRequestException and report is an error (HTTP status "400 Bad request").

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and previously successful tests passed.
