### PR TITLE
Handle CDXException and respond with HTTP 400 Bad Request

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -404,10 +404,12 @@ class FrontEndApp(object):
         try:
             res = requests.get(cdx_url, stream=True)
 
+            status_line = '{} {}'.format(res.status_code, res.reason)
             content_type = res.headers.get('Content-Type')
 
             return WbResponse.bin_stream(StreamIter(res.raw),
-                                         content_type=content_type)
+                                         content_type=content_type,
+                                         status=status_line)
 
         except Exception as e:
             return WbResponse.text_response('Error: ' + str(e), status='400 Bad Request')

--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -4,6 +4,7 @@ from pywb.utils.memento import MementoUtils
 
 from warcio.recordloader import ArchiveLoadFailed
 
+from pywb.warcserver.index.cdxobject import CDXException
 from pywb.warcserver.index.fuzzymatcher import FuzzyMatcher
 from pywb.warcserver.resource.responseloader import  WARCPathLoader, LiveWebLoader, VideoLoader
 
@@ -96,13 +97,27 @@ class IndexHandler(object):
         content_type, res = handler(cdx_iter, fields, params)
         out_headers = {'Content-Type': content_type}
 
-        def check_str(lines):
+        first_line = None
+        try:
+            # raise exceptions early so that they can be handled properly
+            first_line = next(res)
+        except StopIteration:
+            pass
+        except CDXException as e:
+            errs = dict(last_exc=e)
+            return None, None, errs
+
+        def check_str(first_line, lines):
+            if first_line is not None:
+                if isinstance(first_line, six.text_type):
+                    first_line = first_line.encode('utf-8')
+                yield first_line
             for line in lines:
                 if isinstance(line, six.text_type):
                     line = line.encode('utf-8')
                 yield line
 
-        return out_headers, check_str(res), errs
+        return out_headers, check_str(first_line, res), errs
 
 
 #=============================================================================

--- a/tests/test_zipnum_auto_dir.py
+++ b/tests/test_zipnum_auto_dir.py
@@ -46,5 +46,13 @@ class TestZipnumAutoDir(CollsDirMixin, BaseConfigTest):
         assert lines[2] == {"urlkey": "org,iana)/_css/2013.1/fonts/opensans-regular.ttf 20140126200654", "part": "zipnum", "offset": 1692, "length": 235, "lineno": 7}
         assert lines[3] == {"urlkey": "org,iana)/_css/2013.1/fonts/opensans-regular.ttf 20140126200816", "part": "zipnum", "offset": 1927, "length": 231, "lineno": 8}
 
+    def test_paged_index_query_out_of_range(self):
+        res = self.testapp.get(
+            '/testzip/cdx?url=http://iana.org/domains/&matchType=domain&output=json&showPagedIndex=true&pageSize=4&page=10',
+            expect_errors=True)
+
+        assert res.status_code == 400
+        assert res.json == {"message": "Page 10 invalid: First Page is 0, Last Page is 9"}
+
 
 


### PR DESCRIPTION
## Description

WarcServer should handle CDXExceptions and respond with HTTP status "400 Bad Request".

The PR reads the first line of the CDX result early so that the exception is raised and be caught and forwarded as error.

The unit test included in this PR is based on #624 (included in this PR).

## Motivation and Context

- ensures backward-compatibility with the CDXJ server of PyWB 0.33.2
- some CDX clients (eg. [cdx-toolkit](https://pypi.org/project/cdx-toolkit/)) iterate over result pages until an invalid page number is hit and the server responds with "404 Bad Request". If the error is not properly handled and the server responds with status 500, the client tries the same request (with the page number out of range) again and again.

## Screenshots

Log output and stacktrace of the error:
```
Traceback (most recent call last):
  File ".../site-packages/gevent/pywsgi.py", line 970, in handle_one_response
    self.run_application()
  File ".../site-packages/gevent/pywsgi.py", line 918, in run_application
    self.process_result()
  File ".../site-packages/gevent/pywsgi.py", line 902, in process_result
    for data in self.result:
  File ".../site-packages/pywb/warcserver/handlers.py", line 100, in check_str
    for line in lines:
  File ".../site-packages/pywb/warcserver/handlers.py", line 21, in <genexpr>
    return content_type, (cdx.to_cdxj(fields) for cdx in cdx_iter)
  File ".../site-packages/pywb/warcserver/access_checker.py", line 206, in wrap_iter
    for cdx in cdx_iter:
  File ".../site-packages/pywb/warcserver/index/fuzzymatcher.py", line 162, in get_fuzzy_iter
    for cdx in cdx_iter:
  File ".../site-packages/pywb/warcserver/index/cdxops.py", line 132, in <genexpr>
    return (cdx for cdx, _ in zip(cdx_iter, range(limit)))
  File ".../site-packages/pywb/warcserver/index/aggregator.py", line 76, in <genexpr>
    cdx_iter = (add_source(cdx, name) for cdx in cdx_iter)
  File ".../site-packages/pywb/warcserver/index/zipnum.py", line 166, in gen_cdx
    for blk in blocks:
  File ".../site-packages/pywb/warcserver/index/zipnum.py", line 280, in idx_to_cdx
    for idx in idx_iter:
  File ".../site-packages/pywb/warcserver/index/zipnum.py", line 246, in compute_page_range
    raise CDXException(msg.format(curr_page, total_pages - 1))
pywb.warcserver.index.cdxobject.CDXException: Page 1 invalid: First Page is 0, Last Page is 0
2021-03-18T14:44:55Z {'REMOTE_ADDR': '127.0.0.1', 'REMOTE_PORT': '42774', 'HTTP_HOST': 'localhost:45463', (hidden keys: 21)} failed with CDXException

127.0.0.1 - - [2021-03-18 15:44:55] "GET /CC-MAIN-2019-51/index?url=does-not-exist-domain.org&matchType=domain&page=1 HTTP/1.1" 500 161 0.040050
```

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
