### PR TITLE
AccessChecker: exact-match rules not found in single-line ACLJ file, fixes #628

### DIFF
--- a/pywb/warcserver/access_checker.py
+++ b/pywb/warcserver/access_checker.py
@@ -78,6 +78,11 @@ class AccessChecker(object):
 
     EXACT_SUFFIX = '###'  # type: str
     EXACT_SUFFIX_B = b'###'  # type: bytes
+    # rules in the ACL file are followed by a white space (U+0020):
+    # for searching we need a match suffix which sorts/compares after
+    # (resp. before because we use the rev_cmp function). Simply add
+    # another '#' (U+0023 > U+0020)
+    EXACT_SUFFIX_SEARCH_B = b'####'  # type: bytes
 
     def __init__(self, access_source, default_access='allow'):
         """Initialize a new AccessChecker
@@ -148,7 +153,7 @@ class AccessChecker(object):
         params = {'url': url,
                   'urlkey': urlkey,
                   'nosource': 'true',
-                  'exact_match_suffix': self.EXACT_SUFFIX_B
+                  'exact_match_suffix': self.EXACT_SUFFIX_SEARCH_B
                  }
 
         acl_iter, errs = self.aggregator(params)

--- a/pywb/warcserver/test/test_access.py
+++ b/pywb/warcserver/test/test_access.py
@@ -53,6 +53,10 @@ class TestAccess(TempDirTests, BaseTestClass):
         assert edx['urlkey'] == 'com,example)/foo'
         assert edx['access'] == 'exclude'
 
+        edx = access.find_access_rule('https://example.net/abc/path')
+        assert edx['urlkey'] == 'net,example)/abc/path'
+        assert edx['access'] == 'block'
+
         edx = access.find_access_rule('https://example.net/abc/path/other')
         assert edx['urlkey'] == 'net,example)/abc/path'
         assert edx['access'] == 'block'
@@ -114,7 +118,7 @@ class TestAccess(TempDirTests, BaseTestClass):
         assert edx['urlkey'] == 'net,example)/abc/path'
         assert edx['access'] == 'block'
 
-        # exact-only matchc
+        # exact-only match
         edx = access.find_access_rule('https://www.iana.org/')
         assert edx['urlkey'] == 'org,iana)/###'
         assert edx['access'] == 'allow'
@@ -127,4 +131,12 @@ class TestAccess(TempDirTests, BaseTestClass):
         assert edx['urlkey'] == 'org,iana)/'
         assert edx['access'] == 'exclude'
 
+        # exact-only match, first line in *.aclj file
+        edx = access.find_access_rule('https://www.iana.org/exact/match/first/line/aclj/')
+        assert edx['urlkey'] == 'org,iana)/exact/match/first/line/aclj###'
+        assert edx['access'] == 'allow'
 
+        # exact-only match, single rule in *.aclj file
+        edx = access.find_access_rule('https://www.lonesome-rule.org/')
+        assert edx['urlkey'] == 'org,lonesome-rule)/###'
+        assert edx['access'] == 'allow'

--- a/sample_archive/access/pywb.aclj
+++ b/sample_archive/access/pywb.aclj
@@ -1,3 +1,4 @@
+org,iana)/exact/match/first/line/aclj### - {"access": "allow", "url": "https://www.iana.org/exact/match/first/line/aclj/"}
 org,iana)/about - {"access": "block"}
 org,iana)/_css/2013.1/fonts/opensans-semibold.ttf - {"access": "allow"}
 org,iana)/_css - {"access": "exclude"}

--- a/sample_archive/access/single-line.aclj
+++ b/sample_archive/access/single-line.aclj
@@ -1,0 +1,1 @@
+org,lonesome-rule)/### - {"access": "allow", "url": "https://www.lonesome-rule.org/"}


### PR DESCRIPTION
## Motivation and Context

This PR addresses #628.

## Description

### Problem Analysis

The key used to search for a ACL rule is the SURT URL followed by `###`, e.g.
```
org,iana)/path/###
```

The exact-match rule in the ACLJ file consists of the SURT URL followed by `###`, a white space, the timestamp and the JSON data:
```
org,iana)/path### - {"access": "allow", "url": "http://www.iana.org/path/"}
```

Because the rule line sorts before (in reverse alphabetical order) the search key, the "search cursor" is then positioned just after the rule line and not before it. Although AccessChecker requests one additional line (`prev_size=1`) before the search position [line 41](https://github.com/webrecorder/pywb/blob/78a9888b4673b33cfa263b5ced684a9c855331d5/pywb/warcserver/access_checker.py#L41), this has no effect in a single-line file because we reach EOF just after this line, see [binsearch.py, line 78](https://github.com/webrecorder/pywb/blob/78a9888b4673b33cfa263b5ced684a9c855331d5/pywb/utils/binsearch.py#L78). Consequently, AccessChecker cannot match the single rule in the ACLJ file.

### Proposed Solution

As a solution we could extend the search key suffix by one more number sign `#` (U+0023). The search key then compares properly to the key followed by a white space character (U+0020) in the rule file.

Note: Afaics, the above solution would allow to search with `prev_size=0`.

Proof of sort order using the Unix sort command:

```sh
LC_ALL=C sort -r <<HERE
# rules.aclj:
org,iana)/path/### - {...}
org,iana)/path/ - {...}
# search key equal to SURT key in rule file:
org,iana)/path/###
# search key which sorts/compares properly:
org,iana)/path/####
HERE
```
The "new" search key sorts before the exact match rule (and also before any prefix rules):
```
org,iana)/path/####
org,iana)/path/### - {...}
org,iana)/path/###
org,iana)/path/ - {...}
# search key which sorts/compares properly:
# search key equal to SURT key in rule file:
# rules.aclj:
```


## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
