### PR TITLE
WarcServer / CDXJ API: fail with CDXException (Bad Request) if params `page` or `pageSize` are no valid integers

### DIFF
--- a/pywb/warcserver/index/query.py
+++ b/pywb/warcserver/index/query.py
@@ -119,7 +119,11 @@ class CDXQuery(object):
 
     @property
     def page(self):
-        return int(self.params.get('page', 0))
+        try:
+            return int(self.params.get('page', 0))
+        except ValueError:
+            msg = 'Invalid value for page= param: {}'
+            raise CDXException(msg.format(self.params.get('page')))
 
     @property
     def page_size(self):

--- a/pywb/warcserver/index/test/test_zipnum.py
+++ b/pywb/warcserver/index/test/test_zipnum.py
@@ -125,6 +125,7 @@ Exception: No Locations Found for: foo2
 from pywb import get_test_dir
 from pywb.warcserver.index.test.test_cdxops import cdx_ops_test, cdx_ops_test_data
 from pywb.warcserver.warcserver import init_index_agg
+from pywb.warcserver.index.cdxobject import CDXException
 
 import shutil
 import tempfile
@@ -234,6 +235,11 @@ def test_err_file_not_found():
     with pytest.raises(IOError):
         zip_test_err(url='http://iana.org/x', matchType='exact')  # doctest: +IGNORE_EXCEPTION_DETAIL
 
+def test_invalid_int_param():
+    with pytest.raises(CDXException):
+        zip_ops_test_data(url='http://iana.org/domains/example', matchType='exact', pageSize='not-an-integer')
+    with pytest.raises(CDXException):
+        zip_ops_test_data(url='http://iana.org/domains/example', matchType='exact', page='not-an-integer')
 
 
 

--- a/pywb/warcserver/index/zipnum.py
+++ b/pywb/warcserver/index/zipnum.py
@@ -182,7 +182,11 @@ class ZipNumIndexSource(BaseIndexSource):
         if not pagesize:
             pagesize = self.max_blocks
         else:
-            pagesize = int(pagesize)
+            try:
+                pagesize = int(pagesize)
+            except ValueError:
+                msg = 'Invalid value for pageSize= param: {}'
+                raise CDXException(msg.format(pagesize))
 
         last_line = None
 


### PR DESCRIPTION
## Description

If requests to the CDXJ API include invalid `page` or `pageSize` params the server fails with "HTTP 500 Internal Error". It should fail with "HTTP 400 Bad Request" instead.

## Motivation and Context

Seen with CDX client not properly escaping the value of the url param, eg. `http://example.com/do?pagename=homepage&page=UserAction&id=foo&pageSize=1&output=json`.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
