### PR TITLE
Zipnum index: fail if counting pages with filter params

### DIFF
--- a/pywb/warcserver/index/aggregator.py
+++ b/pywb/warcserver/index/aggregator.py
@@ -37,7 +37,9 @@ class BaseAggregator(object):
 
         cdx_iter, errs = self.load_index(query.params)
 
-        cdx_iter = process_cdx(cdx_iter, query)
+        if not query.page_count:
+            cdx_iter = process_cdx(cdx_iter, query)
+
         return cdx_iter, dict(errs)
 
     def load_child_source(self, name, source, params):

--- a/pywb/warcserver/index/test/test_zipnum.py
+++ b/pywb/warcserver/index/test/test_zipnum.py
@@ -227,6 +227,14 @@ def test_blocks_zero_pages():
     res = zip_ops_test_data(url='http://aaa.zz/', matchType='domain', showNumPages=True)
     assert(res == {"blocks": 0, "pages": 0, "pageSize": 10})
 
+def test_blocks_ignore_filter_params():
+    res = zip_ops_test_data(url='*.iana.org', pageSize='4', showNumPages=True, filter='=status:200')
+    assert(res == {"blocks": 38, "pages": 10, "pageSize": 4})
+
+def test_blocks_ignore_timestamp_params():
+    res = zip_ops_test_data(url='*.iana.org', pageSize='4', showNumPages=True, closest='20140126000000')
+    assert(res == {"blocks": 38, "pages": 10, "pageSize": 4})
+
 
 # Errors
 


### PR DESCRIPTION
## Description

Do not apply any filters (param filter, from, to, closest) if counting pages (param showNumPages=true) to avoid that the CDX filter/processing fails if it tries to read keys not present in a page-count result.

## Motivation and Context

Avoid error responses "HTTP 500 Internal Error: 'urlkey'" (also 'url' or 'timestamp') which are not helpful.

Ev., could also argue to turn these into bad request responses. The solution here tries to be backward-compatible to PyWB 0.33.2 where filter params are simply ignored.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
