### PR TITLE
xmlquery: use compressed length when available

### DIFF
--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -314,6 +314,11 @@ class XmlQueryIndexSource(BaseIndexSource):
         cdx['digest'] = self.gettext(item, 'digest')
         cdx['offset'] = self.gettext(item, 'compressedoffset')
         cdx['filename'] = self.gettext(item, 'file')
+
+        length = self.gettext(item, 'compressedendoffset')
+        if length:
+            cdx['length'] = length
+
         return cdx
 
     def gettext(self, item, name):

--- a/pywb/warcserver/index/test/test_xmlquery_indexsource.py
+++ b/pywb/warcserver/index/test/test_xmlquery_indexsource.py
@@ -71,13 +71,16 @@ class TestXmlQueryIndexSource(BaseTestClass):
     @patch('pywb.warcserver.index.indexsource.requests.sessions.Session.get', mock_get)
     def test_exact_query(self):
         res, errs = self.do_query({'url': 'http://example.com/', 'limit': 100})
+        reslist = list(res)
 
         expected = """\
 com,example)/ 20180112200243 example.warc.gz
 com,example)/ 20180216200300 example.warc.gz"""
-        assert(key_ts_res(res) == expected)
+        assert(key_ts_res(reslist) == expected)
         assert(errs == {})
         assert query_url == 'http://localhost:8080/path?q=limit%3A+100+type%3Aurlquery+url%3Ahttp%253A%252F%252Fexample.com%252F'
+        assert reslist[0]['length'] == '123'
+        assert 'length' not in reslist[1]
 
 
     @patch('pywb.warcserver.index.indexsource.requests.sessions.Session.get', mock_get)
@@ -119,6 +122,7 @@ URL_RESPONSE_1 = """
    <results>
        <result>
          <compressedoffset>10</compressedoffset>
+         <compressedendoffset>123</compressedendoffset>
          <mimetype>text/html</mimetype>
          <file>example.warc.gz</file>
          <redirecturl>-</redirecturl>


### PR DESCRIPTION
## Description

Use the compressed length when it's available in XmlQueryIndexSource.

The field is confusingly misnamed `compressedendoffset` in the XML but [OpenWayback](https://github.com/iipc/openwayback/blob/c7fac11479ee4447a71ee337f91018f7808757a2/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdx/format/CompressedLengthCDXField.java#L33) and consequently [OutbackCDX](https://github.com/nla/outbackcdx/blob/5094be4e12f76d083edc72ba2af2d8150dc5170b/src/outbackcdx/XmlQuery.java#L151) actually use this for the "S" CDX field (compressed length).

## Motivation and Context

Without this field when WARC files are accessed over HTTP pywb will make open byte range requests which results in a lot more data being read from disk than necessary.

CC @anjackson 

## Screenshots (if appropriate):

N/A

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.  _(test_force_https failures seem unrelated. I get the same failures with the master branch prior to this change.)_