### PR TITLE
Pending count

### DIFF
--- a/pywb/recorder/recorderapp.py
+++ b/pywb/recorder/recorderapp.py
@@ -24,8 +24,7 @@ class RecorderApp(object):
 
         self.rec_source_name = kwargs.get('name', 'recorder')
 
-        self.create_buff_func = kwargs.get('create_buff_func',
-                                           self.default_create_buffer)
+        self.create_buff_func = kwargs.get('create_buff_func') or self.default_create_buffer
 
         self.write_queue = gevent.queue.Queue()
         gevent.spawn(self._write_loop)

--- a/tests/test_record_dedup.py
+++ b/tests/test_record_dedup.py
@@ -50,3 +50,7 @@ class TestRecordDedup(HttpBinLiveTests, CollsDirMixin, BaseConfigTest, FakeRedis
 
         # ensure only one response/request pair written
         assert records == ['response', 'request']
+
+    def test_redis_pending_count(self):
+        res = self.redis.get("pywb:test-dedup:pending")
+        assert res == b'0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
When using the dedup redis index, also track the number of pending requests in Redis, defaulting to the key `pywb:{coll}:pending`.
This allows automated processes that use pywb for recording to detect when pywb is fully done recording data to WARC and may be exited.
Supports webrecorder/browsertrix-crawler#44

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
