### PR TITLE
xmlquery: remove space after the "limit:" query field name

### DIFF
--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -248,7 +248,7 @@ class XmlQueryIndexSource(BaseIndexSource):
         try:
             limit = params.get('limit')
             if limit:
-                query = 'limit: {0} '.format(limit) + query
+                query = 'limit:{0} '.format(limit) + query
 
             # OpenSearch API requires double-escaping
             # TODO: add option to not double escape if needed

--- a/pywb/warcserver/index/test/test_xmlquery_indexsource.py
+++ b/pywb/warcserver/index/test/test_xmlquery_indexsource.py
@@ -78,7 +78,7 @@ com,example)/ 20180112200243 example.warc.gz
 com,example)/ 20180216200300 example.warc.gz"""
         assert(key_ts_res(reslist) == expected)
         assert(errs == {})
-        assert query_url == 'http://localhost:8080/path?q=limit%3A+100+type%3Aurlquery+url%3Ahttp%253A%252F%252Fexample.com%252F'
+        assert query_url == 'http://localhost:8080/path?q=limit%3A100+type%3Aurlquery+url%3Ahttp%253A%252F%252Fexample.com%252F'
         assert reslist[0]['length'] == '123'
         assert 'length' not in reslist[1]
 


### PR DESCRIPTION
## Description

Remove a space to change `limit: 100` to `limit:100` in the xmlquery protocol to improve compatibility with OutbackCDX.

## Motivation and Context

OutbackCDX can't handle a space here as it decodes fields by splitting on space. As far as I know `limit:` is an OutbackCDXism so I don't think this would have ever worked properly and I don't think any other server implementation (i.e. OWB) supports it. It doesn't seem to break normal browse access but it does affect pywb's "/cdx" API if the client supplies a limit (reported by @wragge).

Note that OutbackCDX 0.8.0+ supports the `&count=` query string parameter that's used in OWB. I didn't know this existed until recently which is how Outback ended up with its own way of doing this. Maybe it'd be better to switch to that instead in future but I'm not doing that in this PR as some people are probably still using older versions of Outback.

## Screenshots (if appropriate):

N/A

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.