### PR TITLE
Access Control Improvements: Embargo + ACL User Support

### DIFF
--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -146,7 +146,9 @@ For example, this header may be set based on IP range, or based on password auth
 
 Further examples of how to set this header will be provided in the deployments section.
 
-**Note: DON'T use custom user-based rules without configuring proper authentication on the Apache or Nginx frontend to set or remove this header, otherwise the ``X-Pywb-ACL-User`` can easily be faked**
+**Note: Do not use the user-based rules without configuring proper authentication on an Apache or Nginx frontend to set or remove this header, otherwise the 'X-Pywb-ACL-User' can easily be faked.**
+
+See the :ref:`config-acl-header` section in Usage for examples on how to configure this header.
 
 
 Access Error Messages

--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -75,6 +75,9 @@ The following blocks access to all URLs older than 1 year, 2 months, 3 weeks and
 Any combination of years, months, weeks and days can be used (as long as at least one is provided) for the ``newer`` or ``older`` embargo settings.
 
 
+Access Control Settings
+=======================
+
 Access Control Files (.aclj)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -1,15 +1,84 @@
 .. _access-control:
 
-Access Control System
----------------------
+Embargo and Access Control
+--------------------------
 
-The access controls system allows for a flexible configuration of rules to allow,
-block or exclude access to individual urls by longest-prefix match.
+The embargo system allows for date-based rules to block access to captures based on their capture dates.
+
+The access controls system provides additional URL-based rules to allow, block or exclude access to specific URL prefixes or exact URLs.
+
+The embargo and access control rules are configured per collection.
+
+Embargo Settings
+================
+
+The embargo system allows restricting access to all URLs within a collection based on the timestamp of each URL.
+Access to these resources is 'embargoed' until the date range is adjusted or the time interval passes.
+
+The embargo can be used to disallow access to captures based on following criteria:
+- Captures before an exact date
+- Captures after an exact date
+- Captures newer than a time interval
+- Captures older than a time interval
+
+Embargo Before/After Exact Date
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To block access to all captures before or after a specific date, use the ``before`` or ``after`` embargo blocks
+with a specific timestamp.
+
+For example, the following blocks access to all URLs captured before 2020-12-26 in the collection ``embargo-before``::
+
+  embargo-before:
+      index_paths: ...
+      archive_paths: ...
+      embargo:
+          before: '20201226'
+
+
+The following blocks access to all URLs captured on or after 2020-12-26 in collection ``embargo-after``::
+
+  embargo-after:
+      index_paths: ...
+      archive_paths: ...
+      embargo:
+          after: '20201226'
+
+Embargo By Time Interval
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The embargo can also be set for a relative time interval, consisting of years, months, weeks and/or days.
+
+
+For example, the following blocks access to all URLs newer than 1 year::
+
+  embargo-newer:
+      ...
+      embargo:
+          newer:
+            years: 1
+
+
+
+The following blocks access to all URLs older than 1 year, 2 months, 3 weeks and 4 days::
+
+  embargo-older:
+      ...
+      embargo:
+          older:
+            years: 1
+            months: 2
+            weeks: 3
+            days: 4
+
+
+Any combination of years, months, weeks and days can be used (as long as at least one is provided) for the ``newer`` or ``older`` embargo settings.
+
 
 Access Control Files (.aclj)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Access controls are set in one or more access control JSON files (.aclj), sorted in reverse alphabetical order.
+URL-based access controls are set in one or more access control JSON files (.aclj), sorted in reverse alphabetical order.
 To determine the best match, a binary search is used (similar to CDXJ) lookup and then the best match is found forward.
 
 An .aclj file may look as follows::
@@ -22,6 +91,8 @@ An .aclj file may look as follows::
 
 Each JSON entry contains an ``access`` field and the original ``url`` field that was used to convert to the SURT (if any).
 
+The JSON entry may also contain a ``user`` field, as explained below.
+
 The prefix consists of a SURT key and a ``-`` (currently reserved for a timestamp/date range field to be added later)
 
 Given these rules, a user would:
@@ -30,19 +101,53 @@ Given these rules, a user would:
 * would receive a 404 not found error when viewing ``http://httpbin.org/anything`` (exclude)
 
 
-Access Types: allow, block, exclude
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Access Types: allow, block, exclude, allow_ignore_embargo
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The available access types are as follows:
 
 - ``exclude`` - when matched, results are excluded from the index, as if they do not exist. User will receive a 404.
 - ``block`` - when matched, results are not excluded from the index, marked with ``access: block``, but access to the actual is blocked. User will see a 451
-- ``allow`` - full access to the index and the resource.
+- ``allow`` - full access to the index and the resource, but may be overriden by embargo
+- ``allow_ignore_embargo`` - full access to the index and resource, overriding any embargo settings
 
 The difference between ``exclude`` and ``block`` is that when blocked, the user can be notified that access is blocked, while
 with exclude, no trace of the resource is presented to the user.
 
-The use of ``allow`` is useful to provide access to more specific resources within a broader block/exclude rule.
+The use of ``allow`` is useful to provide access to more specific resources within a broader block/exclude rule, while ``allow_ignore_embargo``
+can be used to override any embargo settings.
+
+If both are present, the embargo restrictions are checked first and take precedence, unless the ``allow_ignore_embargo`` option is used
+to override the embargo.
+
+
+User-Based Access Controls
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The access control rules can further be customized be specifying different permissions for different 'users'. Since pywb does not have a user system,
+a special header, ``X-Pywb-ACL-User`` can be used to indicate a specific user.
+
+This setting is designed to allow a more priveleged user to access additional setting or override an embargo.
+
+For example, the following access control settings restricts access to ``https://example.com/restricted/`` by default, but allows access for the ``staff`` user::
+
+  com,example)/restricted - {"access": "allow", "user": "staff"}
+  com,example)/restricted - {"access": "block"}
+
+
+Combined with the embargo settings, this can also be used to override the embargo for internal organizational users, while keeping the embargo for general access::
+
+  com,example)/restricted - {"access": "allow_ignore_embargo", "user": "staff"}
+  com,example)/restricted - {"access": "allow"}
+
+To make this work, pywb must be running behind an Apache or Nginx system that is configured to set ``X-Pywb-ACL-User: staff`` based on certain settings.
+
+For example, this header may be set based on IP range, or based on password authentication.
+
+Further examples of how to set this header will be provided in the deployments section.
+
+**Note: DON'T use custom user-based rules without configuring proper authentication on the Apache or Nginx frontend to set or remove this header, otherwise the ``X-Pywb-ACL-User`` can easily be faked**
+
 
 Access Error Messages
 ^^^^^^^^^^^^^^^^^^^^^
@@ -71,6 +176,11 @@ For example, to add the first line to an ACL file ``access.aclj``, one could run
 The URL supplied can be a URL or a SURT prefix. If a SURT is supplied, it is used as is::
 
   wb-manager acl add <collection> com, allow
+
+
+A specific user for user-based rules can also be specified, for example to add ``allow_ignore_embargo`` for user ``staff`` only, run::
+
+  wb-manager acl add <collection> http://httpbin.org/anything/something allow_ignore_embargo staff
 
 
 By default, access control rules apply to a prefix of a given URL or SURT.
@@ -135,6 +245,20 @@ set merge-sorted to find the best match (very similar to the CDXJ index lookup).
 
 Note: It might make sense to separate ``allows.aclj`` and ``blocks.aclj`` into individual files for organizational reasons,
 but there is no specific need to keep more than one access control files.
+
+Finally, ACLJ and embargo settings combined for the same collection might look as follows::
+
+  collections:
+       test:
+            ...
+            embargo:
+                newer:
+                    days: 366
+
+            acl_paths:
+                 - ./path/to/allows.aclj
+                 - ./path/to/blocks.aclj
+
 
 Default Access
 ^^^^^^^^^^^^^^

--- a/docs/manual/cdxserver_api.rst
+++ b/docs/manual/cdxserver_api.rst
@@ -182,7 +182,7 @@ the following modifiers:
 
 
 ``fields``
-^^^^^^
+^^^^^^^^^^
 
 The ``fields`` param can be used to specify which fields to include in the
 output. The standard available fields are usually: ``urlkey``,

--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -300,9 +300,9 @@ Configuring Access Control Header
 
 The :ref:`access-control` system allows users to be granted different access settings based on the value of an ACL header, ``X-pywb-ACL-user``.
 
-The header can be set by Nginx or Apache to grant custom access priviliges based on the IP address, auth settings, or a combination of rules.
+The header can be set via Nginx or Apache to grant custom access priviliges based on IP address, password, or other combination of rules.
 
-For example, to set the value of the header to ``staff`` if the IP of the request is from designated local IP ranges (127.0.0.1, 192.168.1.0/24), the following can be added to the configs.
+For example, to set the value of the header to ``staff`` if the IP of the request is from designated local IP ranges (127.0.0.1, 192.168.1.0/24), the following settings can be added to the configs:
 
 For Nginx::
 

--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -293,6 +293,50 @@ Then, in your config, simply include:
 The configuration assumes uwsgi is started with ``uwsgi uwsgi.ini``
 
 
+.. _config-acl-header:
+
+Configuring Access Control Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :ref:`access-control` system allows users to be granted different access settings based on the value of an ACL header, ``X-pywb-ACL-user``.
+
+The header can be set by Nginx or Apache to grant custom access priviliges based on the IP address, auth settings, or a combination of rules.
+
+For example, to set the value of the header to ``staff`` if the IP of the request is from designated local IP ranges (127.0.0.1, 192.168.1.0/24), the following can be added to the configs.
+
+For Nginx::
+
+  geo $acl_user {
+    # ensure user is set to empty by default
+    default           "";
+
+    # optional: add IP ranges to allow privileged access
+    127.0.0.1         "staff";
+    192.168.0.0/24    "staff";
+  }
+
+  ...
+  location /wayback/ {
+    ...
+    uwsgi_param HTTP_X_PYWB_ACL_USER $acl_user;
+  }
+
+
+For Apache::
+
+    <If "-R '192.168.1.0/24' || -R '127.0.0.1'">
+      RequestHeader set X-Pywb-ACL-User staff
+    </If>
+    # ensure header is cleared if no match
+    <Else>
+      RequestHeader set X-Pywb-ACL-User ""
+    </Else>
+
+}
+
+
+
+
 Running on Subdirectory Path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -704,6 +704,8 @@ class RewriterApp(object):
         headers = {'Content-Length': str(len(req_data)),
                    'Content-Type': 'application/request'}
 
+        headers.update(inputreq.warcserver_headers)
+
         if skip_record:
             headers['Recorder-Skip'] = '1'
 

--- a/pywb/rewrite/rewriteinputreq.py
+++ b/pywb/rewrite/rewriteinputreq.py
@@ -26,6 +26,7 @@ class RewriteInputRequest(DirectWSGIInputRequest):
         self.url = url
         self.rewriter = rewriter
         self.extra_cookie = None
+        self.warcserver_headers = {}
 
         is_proxy = ('wsgiprox.proxy_host' in env)
 
@@ -80,6 +81,11 @@ class RewriteInputRequest(DirectWSGIInputRequest):
                 continue
 
             elif name in ('HTTP_IF_MODIFIED_SINCE', 'HTTP_IF_UNMODIFIED_SINCE'):
+                continue
+
+            elif name == 'HTTP_X_PYWB_ACL_USER':
+                name = name[5:].title().replace('_', '-')
+                self.warcserver_headers[name] = value
                 continue
 
             elif name == 'HTTP_X_FORWARDED_PROTO':

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.0.dev0'
+__version__ = '2.6.0b0'
 
 if __name__ == '__main__':
     print(__version__)

--- a/pywb/warcserver/access_checker.py
+++ b/pywb/warcserver/access_checker.py
@@ -323,7 +323,6 @@ class AccessChecker(object):
 
                 access = rule.get('access', 'exclude')
 
-            print('ACCESS', access, rule)
             if access != 'allow_ignore_embargo' and access != 'exclude':
                 embargo_access = self.check_embargo(url, timestamp)
                 if embargo_access and embargo_access != 'allow':

--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -66,8 +66,10 @@ class IndexHandler(object):
 
         cdx_iter = self.fuzzy(self.index_source, params)
 
+        acl_user = params['_input_req'].env.get("HTTP_X_PYWB_ACL_USER")
+
         if self.access_checker:
-            cdx_iter = self.access_checker(cdx_iter)
+            cdx_iter = self.access_checker(cdx_iter, acl_user)
 
         return cdx_iter
 

--- a/pywb/warcserver/warcserver.py
+++ b/pywb/warcserver/warcserver.py
@@ -210,6 +210,7 @@ class WarcServer(BaseWarcServer):
             archive_paths = None
             acl_paths = None
             default_access = self.default_access
+            embargo = None
         elif isinstance(coll_config, dict):
             index = coll_config.get('index')
             if not index:
@@ -217,6 +218,7 @@ class WarcServer(BaseWarcServer):
             archive_paths = coll_config.get('archive_paths')
             acl_paths = coll_config.get('acl_paths')
             default_access = coll_config.get('default_access', self.default_access)
+            embargo = coll_config.get('embargo')
 
         else:
             raise Exception('collection config must be string or dict')
@@ -245,8 +247,8 @@ class WarcServer(BaseWarcServer):
 
         # ACCESS CONFIG
         access_checker = None
-        if acl_paths:
-            access_checker = AccessChecker(acl_paths, default_access)
+        if acl_paths or embargo:
+            access_checker = AccessChecker(acl_paths, default_access, embargo)
 
         return DefaultResourceHandler(agg, archive_paths,
                                       rules_file=self.rules_file,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wsgiprox>=1.5.1
 fakeredis<1.0
 tldextract
 babel
+python-dateutil

--- a/sample-deploy/pywb-apache.conf
+++ b/sample-deploy/pywb-apache.conf
@@ -14,4 +14,13 @@
     # required: proxy pass to pywb 
     ProxyPass /wayback uwsgi://pywb:8081/
 
+    # optional: set custom header based on IP ranges
+    <If "-R '192.168.1.0/24' || -R '127.0.0.1'">
+      RequestHeader set X-Pywb-ACL-User staff
+    </If>
+    # ensure header is cleared if no match
+    <Else>
+      RequestHeader set X-Pywb-ACL-User ""
+    </Else>
+
 </VirtualHost>

--- a/sample-deploy/pywb-nginx.conf
+++ b/sample-deploy/pywb-nginx.conf
@@ -1,5 +1,18 @@
 # nginx config for running under /wayback/ prefix
 
+
+# set acl_user, defaulting to empty (any public user)
+geo $acl_user {
+  # ensure user is set to empty by default
+  default           "";
+
+  # optional: add IP ranges to allow privileged access
+  127.0.0.1         "staff";
+  192.168.0.0/24    "staff";
+}
+
+
+
 server {
     listen 80;
 
@@ -14,8 +27,12 @@ server {
 
         uwsgi_pass pywb:8081;
 
+
         include uwsgi_params;
         uwsgi_param UWSGI_SCHEME $scheme;
+
+        # pass acl_user (which should be empty by default)
+        uwsgi_param HTTP_X_PYWB_ACL_USER $acl_user;
     }
 }
 

--- a/sample_archive/access/pywb.aclj
+++ b/sample_archive/access/pywb.aclj
@@ -1,7 +1,12 @@
 org,iana)/exact/match/first/line/aclj### - {"access": "allow", "url": "https://www.iana.org/exact/match/first/line/aclj/"}
 org,iana)/about - {"access": "block"}
+org,iana)/about - {"access": "allow", "user": "staff"}
 org,iana)/_css/2013.1/fonts/opensans-semibold.ttf - {"access": "allow"}
 org,iana)/_css - {"access": "exclude"}
 org,iana)/### - {"access": "allow"}
 org,iana)/ - {"access": "exclude"}
 org,example)/?example=1 - {"access": "block"}
+com,example)/?example=2 - {"access": "allow_ignore_embargo"}
+com,example)/?example=1 - {"access": "allow_ignore_embargo", "user": "staff2"}
+com,example)/?example=1 - {"access": "allow", "user": "staff"}
+com,example)/ - {"access": "allow"}

--- a/tests/config_test_access.yaml
+++ b/tests/config_test_access.yaml
@@ -24,4 +24,33 @@ collections:
 
         default_access: block
 
+    pywb-embargo-before:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        embargo:
+            before: '2014012700'
+
+    pywb-embargo-after:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        embargo:
+            after: '2014012700'
+
+    pywb-embargo-older:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        embargo:
+            older:
+                years: 1
+                months: 6
+
+    pywb-embargo-newer:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        embargo:
+            newer:
+                years: 1
+                months: 6
+
+
 

--- a/tests/config_test_access.yaml
+++ b/tests/config_test_access.yaml
@@ -52,5 +52,16 @@ collections:
                 years: 1
                 months: 6
 
+    pywb-embargo-acl:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        embargo:
+            older:
+                years: 1
+
+        acl_paths:
+            - ./sample_archive/access/pywb.aclj
+
+
 
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -40,6 +40,13 @@ class TestACLApp(BaseConfigTest):
 
         assert 'Access Blocked' in resp.text
 
+    def test_allow_via_acl_header(self):
+        resp = self.query('http://www.iana.org/about/')
+
+        assert len(resp.text.splitlines()) == 1
+
+        resp = self.testapp.get('/pywb/mp_/http://www.iana.org/about/', headers={"X-Pywb-Acl-User": "staff"}, status=200)
+
     def test_allowed_more_specific(self):
         resp = self.query('http://www.iana.org/_css/2013.1/fonts/opensans-semibold.ttf')
 

--- a/tests/test_embargo.py
+++ b/tests/test_embargo.py
@@ -35,6 +35,22 @@ class TestEmbargoApp(BaseConfigTest):
         resp = self.testapp.get('/pywb-embargo-newer/20140127mp_/http://example.com/', status=200)
         assert resp.headers['Content-Location'] == 'http://localhost:80/pywb-embargo-newer/20140127171251mp_/http://example.com'
 
+    def test_embargo_ignore_acl(self):
+        # embargoed
+        resp = self.testapp.get('/pywb-embargo-acl/20140126201054mp_/http://example.com/', status=404)
+
+        # ignore embargo
+        resp = self.testapp.get('/pywb-embargo-acl/20140126201054mp_/http://example.com/?example=2', status=200)
+
+
+    def test_embargo_ignore_acl_with_header_only(self):
+        # ignore embargo with custom header only
+        headers = {"X-Pywb-ACL-User": "staff2"}
+        resp = self.testapp.get('/pywb-embargo-acl/20140126201054mp_/http://example.com/?example=1', status=200, headers=headers)
+
+        resp = self.testapp.get('/pywb-embargo-acl/20140126201054mp_/http://example.com/?example=1', status=404)
+
+
 
 
 

--- a/tests/test_embargo.py
+++ b/tests/test_embargo.py
@@ -1,0 +1,40 @@
+from .base_config_test import BaseConfigTest, fmod
+
+import webtest
+import os
+
+from six.moves.urllib.parse import urlencode
+
+
+# ============================================================================
+class TestEmbargoApp(BaseConfigTest):
+    @classmethod
+    def setup_class(cls):
+        super(TestEmbargoApp, cls).setup_class('config_test_access.yaml')
+
+    def test_embargo_before(self):
+        resp = self.testapp.get('/pywb-embargo-before/20140126201054mp_/http://www.iana.org/domains/reserved', status=404)
+
+        resp = self.testapp.get('/pywb-embargo-before/20140127mp_/http://example.com/', status=200)
+        assert resp.headers['Content-Location'] == 'http://localhost:80/pywb-embargo-before/20140127171251mp_/http://example.com'
+
+    def test_embargo_after(self):
+        resp = self.testapp.get('/pywb-embargo-after/20140126201054mp_/http://www.iana.org/domains/reserved', status=200)
+
+        resp = self.testapp.get('/pywb-embargo-after/20140127mp_/http://example.com/', status=200)
+        assert resp.headers['Content-Location'] == 'http://localhost:80/pywb-embargo-after/20130729195151mp_/http://test@example.com/'
+
+    def test_embargo_older(self):
+        resp = self.testapp.get('/pywb-embargo-older/20140126201054mp_/http://www.iana.org/domains/reserved', status=404)
+
+        resp = self.testapp.get('/pywb-embargo-older/20140127mp_/http://example.com/', status=404)
+
+    def test_embargo_newer(self):
+        resp = self.testapp.get('/pywb-embargo-newer/20140126201054mp_/http://www.iana.org/domains/reserved', status=200)
+
+        resp = self.testapp.get('/pywb-embargo-newer/20140127mp_/http://example.com/', status=200)
+        assert resp.headers['Content-Location'] == 'http://localhost:80/pywb-embargo-newer/20140127171251mp_/http://example.com'
+
+
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
This PR adds an embargo system on top of the access control system, allowing blocking of all URLs based on capture date.
The embargo supports blocking:
- captures before or after specific date
- captures older or newer than a specific time interval (in years, months, weeks and/or days)

When combined with ACL rules, the embargo takes precedence, unless the `allow_ignore_embargo` rule is used.

The PR also adds an optional `user` field to the ACL system, allowing specific matches by user, passed to pywb via the `X-pywb-ACL-user` header.

Version bump to 2.6.0b0


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Support for embargo system and custom -user based auth as part of work for: 
https://netpreserve.org/projects/pywb/

Docs: Initial pass on updated docs for Embargo + ACL system.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
