### PR TITLE
Encode url search parameter when performing query

### DIFF
--- a/pywb/static/search.js
+++ b/pywb/static/search.js
@@ -122,7 +122,7 @@ function clearFilters(event) {
 }
 
 function performQuery(url) {
-  var query = [window.wb_prefix + '*?url=' + url];
+  var query = [window.wb_prefix + '*?url=' + encodeURIComponent(url)];
   var filterExpressions = document.getElementById(elemIds.filtering.list)
     .children;
   if (filterExpressions.length) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Searching for URL's with semicolons fails because the url search paramater is not encoded in the request from the frontend to the backend. The backend receives the full URL but in the request to the CDXJ server the request is cutoff at (and including) the first semicolon.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
#656 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
