### PR TITLE
Support for custom data being added via 'PUT /<coll>/record' when…

### DIFF
--- a/docs/manual/configuring.rst
+++ b/docs/manual/configuring.rst
@@ -266,6 +266,7 @@ The full set of configurable options (with their default settings) is as follows
      rollover_idle_secs: 600
      filename_template: my-warc-{timestamp}-{hostname}-{random}.warc.gz
      source_filter: live
+     enable_put_custom_record: false
 
 The required ``source_coll`` setting specifies the source collection from which to load content that will be recorded.
 Most likely this will be the :ref:`live-web` collection, which should also be defined. 
@@ -340,6 +341,23 @@ When any dedup_policy, pywb can also access the dedup Redis index, along with an
 
 This feature is still experimental but should generally work. Additional options for working with the Redis Dedup index will be added in the futuer.
 
+
+.. _put-custom-record:
+
+Adding Custom Resource Records
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+pywb now also supports adding custom data to a WARC ``resource`` record. This can be used to add custom resources, such as screenshots, logs, error messages,
+etc.. that are not normally captured as part of recording, but still useful to store in WARCs.
+
+To add a custom resources, simply call ``PUT /<coll>/record`` with the data to be added as the request body and the type of the data specified as the content-type. The ``url`` can be specified as a query param.
+
+For example, adding a custom record ``file:///my-custom-resource`` containing ``Some Custom Data`` can be done using ``curl`` as follows::
+
+  curl -XPUT "localhost:8080/my-web-archive/record?url=file:///my-custom-resource" --data "Some Custom Data"
+
+
+This feature is only available if ``enable_put_custom_record: true`` is set in the recorder config.
 
 
 .. _auto-fetch:

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.0b3'
+__version__ = '2.6.0b4'
 
 if __name__ == '__main__':
     print(__version__)

--- a/tests/config_test_record.yaml
+++ b/tests/config_test_record.yaml
@@ -2,7 +2,9 @@ debug: true
 
 collections_root: _test_colls
 
-recorder: live
+recorder:
+  source_coll: live
+  enable_put_custom_record: true
 
 collections:
     'live': '$live'

--- a/tests/test_record_replay.py
+++ b/tests/test_record_replay.py
@@ -136,6 +136,18 @@ class TestRecordReplay(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):
         assert to_path('collection="test2"') in link_lines[3]
         #assert to_path('collection="test"') in link_lines[4]
 
+    def test_put_custom_record(self):
+        payload = b'<html><body>This is custom data added directly. <a href="/test">Link</a></body></html>'
+        res = self.testapp.put('/test2/record?url=https://example.com/custom/record', params=payload, content_type="text/html")
+
+    def test_replay_custom_record(self, fmod):
+        self.ensure_empty()
+
+        fmod_slash = fmod + '/' if fmod else ''
+        res = self.get('/test2/{0}https://example.com/custom/record', fmod_slash)
+        assert res.content_type == 'text/html'
+        assert 'This is custom data added directly. <a href="/test2/' in res.text
+
 
 # ============================================================================
 class TestRecordCustomConfig(HttpBinLiveTests, CollsDirMixin, BaseConfigTest):


### PR DESCRIPTION
… in recording mode and 'enable_put_custom_record: true' set in 'recorder' config

- url specified via 'url' query arg and content type via request Content-Type
- bump version to 2.6.0b4

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

Adds support for adding custom WARC data (as 'resource' records) via a PUT request to `/<coll>/record`.
Must be enabled via `enable_put_custom_record` in recorder config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Useful for adding external screenshots, other data that is not directly captured from the web.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
