### PR TITLE
rewrite: avoid rewriting fields named 'eval' on arbitrary objects

### DIFF
--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -101,9 +101,13 @@ if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ this.__WB_source = obj; 
 
         rules = [
             # rewriting 'eval(....)' - invocation
-            (r'(?<![$])\beval\s*\(', self.add_prefix('WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).'), 0),
+            (r'(?<![$.])\beval\s*\(', self.add_prefix('WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).'), 0),
             # rewriting 'x = eval' - no invocation
-            (r'(?<![$])\beval\b', self.add_prefix('WB_wombat_'), 0),
+            (r'(?<![$.])\beval\b(?!\s*:)', self.add_prefix('WB_wombat_'), 0),
+            # rewriting 'window.eval(....)' - invocation
+            (r'(?<=\bwindow\.)eval\s*\(', self.add_prefix('WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).'), 0),
+            # rewriting 'x = window.eval' - no invocation
+            (r'(?<=\bwindow\.)eval\b', self.add_prefix('WB_wombat_'), 0),
             (r'(?<=\.)postMessage\b\(', self.add_prefix('__WB_pmw(self).'), 0),
             (r'(?<![$.])\s*location\b\s*[=]\s*(?![=])', self.add_suffix(check_loc), 0),
             # rewriting 'return this'

--- a/pywb/rewrite/test/test_regex_rewriters.py
+++ b/pywb/rewrite/test/test_regex_rewriters.py
@@ -233,6 +233,18 @@ r"""
 >>> _test_js_obj_proxy('window.eval(a);')
 'window.WB_wombat_runEval(function _____evalIsEvil(_______eval_arg$$) { return eval(_______eval_arg$$); }.bind(this)).eval(a);'
 
+>>> _test_js_obj_proxy('x = window.eval; x(a);')
+'x = window.WB_wombat_eval; x(a);'
+
+>>> _test_js_obj_proxy('obj = { eval : 1 }')
+'obj = { eval : 1 }'
+
+>>> _test_js_obj_proxy('x = obj.eval')
+'x = obj.eval'
+
+>>> _test_js_obj_proxy('x = obj.eval(a)')
+'x = obj.eval(a)'
+
 #=================================================================
 # XML Rewriting
 #=================================================================


### PR DESCRIPTION
## Description

This changes the eval rewriting regex rules to not match fields named eval on arbitrary objects like:
```js
obj = { eval: function() { return 1; } };
obj.eval();
```
It also adds a second set of rules to ensure `window.eval` continues to match in cases such as:

```js
x = window.eval;
window.eval(a);
```
Note: This does introduce false-negatives like `obj = window; obj.eval(a)` and `(true?eval:null)(a)`. These seem like they should be rare in normal code though.

## Motivation and Context

Fixes issue #663 in which the rewriter breaks less.js as it uses a lot of objects that have methods named eval that have nothing to do with JavaScript's global `eval()` function.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
