### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/manual/owb-to-pywb-deploy.rst
+++ b/docs/manual/owb-to-pywb-deploy.rst
@@ -51,7 +51,7 @@ See the :ref:`nginx-deploy` and :ref:`apache-deploy` sections for more info on d
 Working Docker Compose Examples
 -------------------------------
 
-The pywb `Deployment Examples <https://github.com/webrecorder/pywb/blob/docs/sample-deploy/>`_ include working examples of deploying pywb with Nginx, Apache and OutbackCDX
+The pywb `Deployment Examples <https://github.com/webrecorder/pywb/blob/main/sample-deploy/>`_ include working examples of deploying pywb with Nginx, Apache and OutbackCDX
 in Docker using Docker Compose, widely available container orchestration tools.
 
 See `Installing Docker <https://docs.docker.com/get-docker/>`_ and `Installing Docker Compose <https://docs.docker.com/compose/install/>`_ for instructions on how to install these tools.

--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -357,7 +357,7 @@ Deployment Examples
 The ``sample-deploy`` directory includes working Docker Compose examples for deploying pywb with Nginx and Apache on the ``/wayback`` subdirectory.
 
 See:
- - `Docker Compose Nginx <https://github.com/webrecorder/pywb/blob/docs/sample-deploy/docker-compose-nginx.yaml>`_ for sample Nginx config.
- - `Docker Compose Apache <https://github.com/webrecorder/pywb/blob/docs/sample-deploy/docker-compose-apache.yaml>`_ for sample Apache config.
- - `uwsgi_subdir.ini <https://github.com/webrecorder/pywb/blob/docs/sample-deploy/uwsgi_subdir.ini>`_ for example subdirectory uwsgi config.
+ - `Docker Compose Nginx <https://github.com/webrecorder/pywb/blob/main/sample-deploy/docker-compose-nginx.yaml>`_ for sample Nginx config.
+ - `Docker Compose Apache <https://github.com/webrecorder/pywb/blob/main/sample-deploy/docker-compose-apache.yaml>`_ for sample Apache config.
+ - `uwsgi_subdir.ini <https://github.com/webrecorder/pywb/blob/main/sample-deploy/uwsgi_subdir.ini>`_ for example subdirectory uwsgi config.
 


### PR DESCRIPTION
## Description
Fixes links in the docs that pointed to a now non-existent branch.

## Motivation and Context
To fix broken links.

## Types of changes
documentation