### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pywb/utils/test/test_binsearch.py
+++ b/pywb/utils/test/test_binsearch.py
@@ -105,7 +105,7 @@ def test_rev_merge():
 
 
     # check reverse merge: verify merging of lists, than reversing
-    # eqauls merging with reverse=True of reversed lists
+    # equals merging with reverse=True of reversed lists
     assert (list(reversed(list(merge(lines1, lines2)))) ==
             list(merge(reversed(lines1), reversed(lines2), reverse=True)))
 

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -230,7 +230,7 @@ class WARCPathLoader(DefaultResolverMixin, BaseLoader):
                 http_headers_buff = http_headers.to_bytes()
 
                 # if new http_headers_buff is different length,
-                # attempt to adjust content-lenghth on the WARC record
+                # attempt to adjust content-length on the WARC record
                 if orig_size and len(http_headers_buff) != orig_size:
                     orig_cl = payload.rec_headers.get_header('Content-Length')
                     if orig_cl:

--- a/pywb/warcserver/resource/test/test_pathresolvers.py
+++ b/pywb/warcserver/resource/test/test_pathresolvers.py
@@ -161,7 +161,7 @@ class TestPathIndex(object):
         res = DefaultResolverMixin.make_best_resolver(a_file)
         assert isinstance(res, PathIndexResolver)
 
-        # a dir -- asume prefix
+        # a dir -- assume prefix
         res = DefaultResolverMixin.make_best_resolver(a_dir)
         assert isinstance(res, PrefixResolver)
 


### PR DESCRIPTION
There are small typos in:
- pywb/utils/test/test_binsearch.py
- pywb/warcserver/resource/responseloader.py
- pywb/warcserver/resource/test/test_pathresolvers.py

Fixes:
- Should read `length` rather than `lenghth`.
- Should read `equals` rather than `eqauls`.
- Should read `assume` rather than `asume`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md