### PR TITLE
Add periods to end of list of access types in docs to make consistent

### DIFF
--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -113,8 +113,8 @@ The available access types are as follows:
 
 - ``exclude`` - when matched, results are excluded from the index, as if they do not exist. User will receive a 404.
 - ``block`` - when matched, results are not excluded from the index, but access to the actual content is blocked. User will see a 451.
-- ``allow`` - full access to the index and the resource, but may be overriden by embargo
-- ``allow_ignore_embargo`` - full access to the index and resource, overriding any embargo settings
+- ``allow`` - full access to the index and the resource, but may be overriden by embargo.
+- ``allow_ignore_embargo`` - full access to the index and resource, overriding any embargo settings.
 
 The difference between ``exclude`` and ``block`` is that when blocked, the user can be notified that access is blocked, while
 with exclude, no trace of the resource is presented to the user.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
The top two access types end in a ".". The final two do not. This simply adds periods to the third and fourth list items to make punctuation consistent among the bullets.

## Motivation and Context
The motivation is to improve the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [X] All new and existing tests passed.
