### PR TITLE
Modify examples in cdx-indexer help text to do as stated

### DIFF
--- a/pywb/indexer/cdxindexer.py
+++ b/pywb/indexer/cdxindexer.py
@@ -331,13 +331,13 @@ are supported.
 Some examples:
 
 * Create "example.cdx" index from example.warc.gz
-{0} ./cdx/example.cdx ./warcs/example.warc.gz
+{0} --output ./cdx/example.cdx ./warcs/example.warc.gz
 
 * Create "combined.cdx", a combined, sorted index of all warcs in ./warcs/
-{0} --sort combined.cdx ./warcs/
+{0} --sort --output combined.cdx ./warcs/
 
 * Create a sorted cdx per file in ./cdx/ for each archive file in ./warcs/
-{0} --sort ./cdx/ ./warcs/
+{0} --sort --output ./cdx/ ./warcs/
 """.format(os.path.basename(sys.argv[0]))
 
     sort_help = """


### PR DESCRIPTION
## Description
Modifies the examples given in the help text of the `cdx-indexer` script.

## Motivation and Context
Currently the examples given at the end of the `cdx-indexer` script's help text do not work as stated because the intended output locations are being interpreted as input locations. Here is the text at the end of the help given with `cdx-indexer -h`:

```
Some examples:

* Create "example.cdx" index from example.warc.gz
cdxindexer.py ./cdx/example.cdx ./warcs/example.warc.gz

* Create "combined.cdx", a combined, sorted index of all warcs in ./warcs/
cdxindexer.py --sort combined.cdx ./warcs/

* Create a sorted cdx per file in ./cdx/ for each archive file in ./warcs/
cdxindexer.py --sort ./cdx/ ./warcs/
```
Here's output of running the first example, though the two paths do exist:

```
$ ls -l ./cdx ./warcs/example.warc.gz 
-rw-r--r-- 1 user group 309111734 Nov 22 15:15 ./warcs/example.warc.gz

./cdx:
total 0
$ cdx-indexer ./cdx/example.cdx ./warcs/example.warc.gz
 CDX N b a m s k r M S V g
Traceback (most recent call last):
  File "/home/me/virtualenvs/pywb/bin/cdx-indexer", line 33, in <module>
    sys.exit(load_entry_point('pywb==2.6.2', 'console_scripts', 'cdx-indexer')())
  File "/home/me/virtualenvs/pywb/lib/python3.7/site-packages/pywb-2.6.2-py3.7.egg/pywb/indexer/cdxindexer.py", line 471, in main
    minimal=cmd.minimal_cdxj)
  File "/home/me/virtualenvs/pywb/lib/python3.7/site-packages/pywb-2.6.2-py3.7.egg/pywb/indexer/cdxindexer.py", line 298, in write_multi_cdx_index
    with open(fullpath, 'rb') as infile:
FileNotFoundError: [Errno 2] No such file or directory: './cdx/example.cdx'

```
This tiny PR changes the examples given, so they work as expected:

```
Some examples:

* Create "example.cdx" index from example.warc.gz
cdx-indexer --output ./cdx/example.cdx ./warcs/example.warc.gz

* Create "combined.cdx", a combined, sorted index of all warcs in ./warcs/
cdx-indexer --sort --output combined.cdx ./warcs/

* Create a sorted cdx per file in ./cdx/ for each archive file in ./warcs/
cdx-indexer --sort --output ./cdx/ ./warcs/
```
