### PR TITLE
live route fix:

### DIFF
--- a/pywb/warcserver/index/test/test_indexsource.py
+++ b/pywb/warcserver/index/test/test_indexsource.py
@@ -26,12 +26,12 @@ class TestIndexSources(FakeRedisTests, BaseTestClass):
         cls.all_sources = {
             'file': FileIndexSource(TEST_CDX_PATH + 'iana.cdxj'),
             'redis': RedisIndexSource('redis://localhost:6379/2/test:rediscdx'),
-            'remote_cdx': RemoteIndexSource('https://webenact.rhizome.org/all/cdx?url={url}',
-                              'https://webenact.rhizome.org/all/{timestamp}id_/{url}'),
+            'remote_cdx': RemoteIndexSource('https://webenact.rhizome.org/excellences-and-perfections/cdx?url={url}',
+                              'https://webenact.rhizome.org/excellences-and-perfections/{timestamp}id_/{url}'),
 
-            'memento': MementoIndexSource('https://webenact.rhizome.org/all/{url}',
-                               'https://webenact.rhizome.org/all/timemap/link/{url}',
-                               'https://webenact.rhizome.org/all/{timestamp}id_/{url}')
+            'memento': MementoIndexSource('https://webenact.rhizome.org/excellences-and-perfections/{url}',
+                               'https://webenact.rhizome.org/excellences-and-perfections/timemap/link/{url}',
+                               'https://webenact.rhizome.org/excellences-and-perfections/{timestamp}id_/{url}')
         }
 
     @pytest.fixture(params=local_sources)
@@ -99,14 +99,10 @@ org,iana)/domains/root/servers 20140126201227 iana.warc.gz"""
         res, errs = self.query_single_source(remote_source, dict(url=url))
 
         expected = """\
-com,instagram)/amaliaulman 20141014150552 https://webenact.rhizome.org/all/20141014150552id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014152101 https://webenact.rhizome.org/all/20141014152101id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014155217 https://webenact.rhizome.org/all/20141014155217id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014160238 https://webenact.rhizome.org/all/20141014160238id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/all/20141014162333id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014163116 https://webenact.rhizome.org/all/20141014163116id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014171636 https://webenact.rhizome.org/all/20141014171636id_/http://instagram.com/amaliaulman
-com,instagram)/amaliaulman 20141014171954 https://webenact.rhizome.org/all/20141014171954id_/http://instagram.com/amaliaulman"""
+com,instagram)/amaliaulman 20141014150552 https://webenact.rhizome.org/excellences-and-perfections/20141014150552id_/http://instagram.com/amaliaulman
+com,instagram)/amaliaulman 20141014155217 https://webenact.rhizome.org/excellences-and-perfections/20141014155217id_/http://instagram.com/amaliaulman
+com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/excellences-and-perfections/20141014162333id_/http://instagram.com/amaliaulman
+com,instagram)/amaliaulman 20141014171636 https://webenact.rhizome.org/excellences-and-perfections/20141014171636id_/http://instagram.com/amaliaulman"""
         assert(key_ts_res(res, 'load_url') == expected)
         assert(errs == {})
 
@@ -117,7 +113,7 @@ com,instagram)/amaliaulman 20141014171954 https://webenact.rhizome.org/all/20141
         res, errs = self.query_single_source(remote_source, dict(url=url, closest='20141014162332', limit=1, allowFuzzy='0'))
 
         expected = """\
-com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/all/20141014162333id_/http://instagram.com/amaliaulman"""
+com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/excellences-and-perfections/20141014162333id_/http://instagram.com/amaliaulman"""
 
         assert(key_ts_res(res, 'load_url') == expected)
         assert(errs == {})
@@ -128,21 +124,21 @@ com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/all/20141
         res, errs = self.query_single_source(remote_source, dict(url=url, closest='20141014162332', limit=1))
 
         expected = """\
-com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/all/20141014162333id_/http://instagram.com/amaliaulman"""
+com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/excellences-and-perfections/20141014162333id_/http://instagram.com/amaliaulman"""
 
         assert(key_ts_res(res, 'load_url') == expected)
         assert(errs == {})
 
     # Url Match -- Wb Memento
     def test_remote_closest_wb_memento_loader(self):
-        replay = 'https://webenact.rhizome.org/all/{timestamp}id_/{url}'
+        replay = 'https://webenact.rhizome.org/excellences-and-perfections/{timestamp}id_/{url}'
         source = WBMementoIndexSource(replay, '', replay)
 
         url = 'http://instagram.com/amaliaulman'
         res, errs = self.query_single_source(source, dict(url=url, closest='20141014162332', limit=1))
 
         expected = """\
-com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/all/20141014162333id_/http://instagram.com/amaliaulman"""
+com,instagram)/amaliaulman 20141014162333 https://webenact.rhizome.org/excellences-and-perfections/20141014162333id_/http://instagram.com/amaliaulman"""
 
         assert(key_ts_res(res, 'load_url') == expected)
         assert(errs == {})

--- a/tests/test_redirect_classic.py
+++ b/tests/test_redirect_classic.py
@@ -74,6 +74,10 @@ class TestRedirectClassic(BaseConfigTest):
         resp = self.get('/live/{0}http://example.com/?test=test', fmod_slash)
         assert resp.status_int == 200
 
+    def test_live_top_frame(self):
+        resp = self.testapp.get('/live/http://example.com/?test=test')
+        assert 'top_url' not in resp.text
+
     def test_replay_limit_cdx(self):
         resp = self.testapp.get('/pywb/cdx?url=http://www.iana.org/*&output=json')
         assert resp.content_type == 'text/x-ndjson'


### PR DESCRIPTION
When 'redirect_to_exact' is enabled, the top-frame expects a redirect for top-frame.
However, when running in live mode, do not expect redirect for top-frame, render live top-frame same as before
Tests: ensure top-frame loads correctly for live mode with redirect_to_exact enabled
Tests: fix webneact index tests

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
