### PR TITLE
Markupsafe fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+pywb 2.6.5 changelist
+~~~~~~~~~~~~~~~~~~~~~
+
+* fix build: add 'markupsafe<2.1.0' to requirements
+
+
 pywb 2.6.4 changelist
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.4'
+__version__ = '2.6.5'
 
 if __name__ == '__main__':
     print(__version__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wsgiprox>=1.5.1
 fakeredis<1.0
 tldextract
 python-dateutil
+markupsafe<2.1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Need to add dependency for 'markupsafe<2.1.0' as latest version breaks pywb
Bump to 2.6.5