### PR TITLE
Increase uwsgi_buffer_size for nginx config

### DIFF
--- a/sample-deploy/pywb-nginx.conf
+++ b/sample-deploy/pywb-nginx.conf
@@ -26,6 +26,7 @@ server {
         resolver 127.0.0.1;
 
         uwsgi_pass pywb:8081;
+        uwsgi_buffer_size 8k;
 
 
         include uwsgi_params;


### PR DESCRIPTION
## Description

I was playing back a YouTube video and noticed that the playback worked
fine with using uwsgi/pywb directly but failed when using nginx. I think
a very long HTTP Link header was causing nginx to hang up. I increased
the uwsgi_buffer_size to 8k and the problem went away. Maybe this will
save someone else some time if it is increased?

## Motivation and Context

https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_buffer_size

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
