### PR TITLE
Add missing translation for the filter-epression field placeholder

### DIFF
--- a/pywb/templates/search.html
+++ b/pywb/templates/search.html
@@ -135,7 +135,7 @@ window.wb_prefix = "{{ wb_prefix }}";
                         <div class="row">
                             <label for="filter-expression" class="col-form-label col-3">{% trans %}Expr:{% endtrans %}</label>
                             <input type="text" id="filter-expression" class="form-control col-7"
-                                   placeholder="Enter an expression to filter by"
+                                   placeholder="{% trans %}Enter an expression to filter by{% endtrans %}"
                             >
                         </div>
                     </div>


### PR DESCRIPTION
## Description
Add the `{% trans %}`/`{% endtrans %}` tags for the `placeholder` text of the `filter-expression` field on the `search.html` page.

## Motivation and Context
Needed in order for translators to be able to translate it to other languages.

## Screenshots (if appropriate):
![2022-05-17-152014_1190x565_scrot](https://user-images.githubusercontent.com/4865723/168822290-6afde24d-453c-49e0-ab5f-edfdf9b9305f.png)
![2022-05-17-152735_1146x558_scrot](https://user-images.githubusercontent.com/4865723/168822294-4d1e6d94-9dba-49f1-bc6b-acf733e313cc.png)

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.

The `tests/test_auto_colls.py::TestManagedColls::test_add_static` test is failing with and without this change. The other 807 tests passed.