### PR TITLE
Activate field validation when expanding the advanced options

### DIFF
--- a/pywb/static/search.js
+++ b/pywb/static/search.js
@@ -29,7 +29,8 @@ var elemIds = {
   match: 'match-type-select',
   url: 'search-url',
   form: 'search-form',
-  resultsNewWindow: 'open-results-new-window'
+  resultsNewWindow: 'open-results-new-window',
+  advancedOptions: 'advanced-options'
 };
 
 function makeCheckDateRangeChecker(dtInputId, dtBadNotice) {
@@ -158,6 +159,13 @@ function performQuery(url) {
   }
 }
 
+function validateFields(form) {
+  if (!didSetWasValidated) {
+    form.classList.add('was-validated');
+    didSetWasValidated = true;
+  }
+}
+
 $(document).ready(function() {
   $('[data-toggle="tooltip"]').tooltip({
     container: 'body',
@@ -180,12 +188,12 @@ $(document).ready(function() {
     event.stopPropagation();
     var url = searchURLInput.value;
     if (!url) {
-      if (!didSetWasValidated) {
-        form.classList.add('was-validated');
-        didSetWasValidated = true;
-      }
+      validateFields(form);
       return;
     }
     performQuery(url);
   });
+  document.getElementById(elemIds.advancedOptions).onclick = function() {
+    validateFields(form);
+  }
 });

--- a/pywb/templates/search.html
+++ b/pywb/templates/search.html
@@ -45,7 +45,7 @@ window.wb_prefix = "{{ wb_prefix }}";
                     {% trans %}Search{% endtrans %}
                 </button>
                 <button class="btn btn-outline-info float-right mr-3" type="button" role="button"
-                        data-toggle="collapse" data-target="#advancedOptions"
+                        data-toggle="collapse" data-target="#advancedOptions" id="advanced-options"
                         aria-expanded="false" aria-controls="advancedOptions" aria-label="Advanced Search Options">
                     {{ _('Advanced Search Options') }}
                 </button>


### PR DESCRIPTION
## Description
Add an id tag to the advanced search options button and bind a lambda function to clicking on it in order to activate field validation when expanding the advanced options.

## Motivation and Context
Having to click Search with an empty URL in order to get instructions about what format the from and to timestamps should be is not obvious. If you have already entered a URL there's no way to get feedback on entered values short of removing the URL and clicking Search.
It would make more sense to enable field validation as soon as the advanced options are expanded. (I'm guessing it is not enabled from start to avoid getting an error message on every new search.)

## Screenshots (if appropriate):
Current behavior: 
![2022-05-18-132616_1147x561_scrot](https://user-images.githubusercontent.com/4865723/169028670-21f0077d-ae43-40b4-b770-9acd6d438f9b.png)
Expected behavior: 
![2022-05-18-132806_1137x590_scrot](https://user-images.githubusercontent.com/4865723/169028737-8c2334df-1390-41f4-b709-d737427ab024.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
The `tests/test_auto_colls.py::TestManagedColls::test_add_static` test fails with or without this change but the other 807 tests pass.