### PR TITLE
S3 loader to use boto3 built-in credential configuration

### DIFF
--- a/pywb/utils/loaders.py
+++ b/pywb/utils/loaders.py
@@ -185,7 +185,8 @@ class BlockLoader(BaseLoader):
     """
     a loader which can stream blocks of content
     given a uri, offset and optional length.
-    Currently supports: http/https and file/local file system
+    Currently supports: http/https, file/local file system,
+    pkg, WebHDFS, S3
     """
 
     loaders = {}
@@ -393,14 +394,15 @@ class S3Loader(BaseLoader):
 
         def s3_load(anon=False):
             if not self.client:
+                s3_client_args = {}
                 if anon:
-                    config = Config(signature_version=UNSIGNED)
-                else:
-                    config = None
+                    s3_client_args['config'] = Config(signature_version=UNSIGNED)
+                if aws_access_key_id:
+                    s3_client_args['aws_access_key_id'] = aws_access_key_id
+                    s3_client_args['aws_secret_access_key'] = aws_secret_access_key
 
-                client = boto3.client('s3', aws_access_key_id=aws_access_key_id,
-                                      aws_secret_access_key=aws_secret_access_key,
-                                      config=config)
+                client = boto3.client('s3', **s3_client_args)
+
             else:
                 client = self.client
 

--- a/pywb/utils/test/test_loaders.py
+++ b/pywb/utils/test/test_loaders.py
@@ -97,9 +97,18 @@ from pywb import get_test_dir
 
 test_cdx_dir = get_test_dir() + 'cdx/'
 
-@pytest.mark.skip("skip for now, made need different s3 source")
-def test_s3_read_1():
+def s3_authenticated_access_verification(bucket):
+    import boto3, botocore
+    s3_client = boto3.client('s3')
+    try:
+        s3_client.head_bucket(Bucket=bucket)
+    except botocore.exceptions.NoCredentialsError:
+        pytest.skip("Skipping S3Loader test for authenticated reads: no credentials configured")
+
+def test_s3_read_authenticated_1():
     pytest.importorskip('boto3')
+
+    s3_authenticated_access_verification('commoncrawl')
 
     res = BlockLoader().load('s3://commoncrawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz',
                              offset=53235662,
@@ -112,9 +121,10 @@ def test_s3_read_1():
     assert reader.readline() == b'WARC/1.0\r\n'
     assert reader.readline() == b'WARC-Type: response\r\n'
 
-@pytest.mark.skip("skip for now, made need different s3 source")
-def test_s3_read_2():
+def test_s3_read_authenticated_2():
     pytest.importorskip('boto3')
+
+    s3_authenticated_access_verification('commoncrawl')
 
     res = BlockLoader().load('s3://commoncrawl/crawl-data/CC-MAIN-2015-11/index.html')
 


### PR DESCRIPTION
- enables the S3 loader to use [boto3 built-in methods to configure AWS credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)
- re-enables the S3 loader tests reading from s3://commoncrawl/ to test authenticated S3 access

## Description

So far, authenticated reads from S3 were only possible by explicitly passing AWS credentials to the S3Loader. Boto3 supports more multiple methods to [configure/provide credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).

The priority when configuring the S3 client is now:
1. use the credentials passed into the S3Loader
2. (newly introduced) try other boto3 built-in methods (environment variables, configuration files, IAM roles)
3. try unauthenticated / anonymous access (no AWS account required)

The S3Loader unit tests are enabled again (disabled in 403167fb) and adapted to test authenticated reads from s3://commoncrawl/. If no AWS credentials are set up, the tests are skipped. I've successfully run the tests
- using a profile selected by the environment variable AWS_PROFILE
- on a EC2 instance with an IAM role attached which grants permissions to read from s3://commoncrawl/ 

## Motivation and Context

[Best practice](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#best-practices-for-configuring-credentials) is to use methods where credentials are not visible and may not leak into log files or stack traces in error messages. Passing credentials by URL (s3://user@password:bucket/) may induce a security risk.

In April 2022 access to Common Crawl data via the S3 API was restricted to AWS users only. Users with no AWS account are required to switch to HTTP requests using a different base URL, see [introducing CloudFront access](https://commoncrawl.org/2022/03/introducing-cloudfront-access-to-common-crawl-data/) and [general instructions to access Common Crawl data](https://commoncrawl.org/access-the-data/).

## Types of changes

- [x] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
