### PR TITLE
Add missing org/image to docker run commands

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -218,13 +218,13 @@ The following will run pywb in Docker directly on port 80:
 
 .. code:: console
 
-      docker run -p 80:8080 -v /webarchive-data/:/webarchive
+      docker run -p 80:8080 -v /webarchive-data/:/webarchive webrecorder/pywb
 
 To run pywb in Docker behind a local nginx (as shown below), port 8081 should also be mapped:
 
 .. code:: console
 
-      docker run -p 8081:8081 -v /webarchive-data/:/webarchive
+      docker run -p 8081:8081 -v /webarchive-data/:/webarchive webrecorder/pywb
 
 
 See :ref:`getting-started-docker` for more info on using pywb with Docker.


### PR DESCRIPTION
Hi there, folks!

## Description
This updates the [_Docker Deployment_ section](https://pywb.readthedocs.io/en/latest/manual/usage.html#docker-deployment) to include the image organisation/name to the sample commands


