### PR TITLE
Format error messages

### DIFF
--- a/pywb/static/css/base.css
+++ b/pywb/static/css/base.css
@@ -39,3 +39,7 @@ header .language-select a:hover {
     text-decoration: underline;
 }
 
+.error pre {
+    white-space: pre-wrap;
+    text-align: left;
+}

--- a/pywb/templates/error.html
+++ b/pywb/templates/error.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Pywb Error') }}{% endblock %}
 {% block body %}
-<div class="container text-danger">
+<div class="container text-danger error">
     <div class="row justify-content-center">
         <h2 class="display-2">Pywb Error</h2>
     </div>


### PR DESCRIPTION
## Description

Currently error messages display on a single line that can be difficult to scroll. This updates the CSS slightly to allow the message to spread over multiple lines if needed.

## Motivation and Context

To make it (a little bit) easier to read error messages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [X] All new and existing tests passed.
