### PR TITLE
Ensure CDX status is a string

### DIFF
--- a/pywb/warcserver/index/cdxobject.py
+++ b/pywb/warcserver/index/cdxobject.py
@@ -251,7 +251,11 @@ class CDXObject(OrderedDict):
 
     @classmethod
     def json_decode(cls, string):
-        return json_decode(string, object_pairs_hook=OrderedDict)
+        cdx_block = json_decode(string, object_pairs_hook=OrderedDict)
+        # other parts of pywb expect status to be a string and not an integer
+        if cdx_block and type(cdx_block.get('status')) == int:
+            cdx_block['status'] = str(cdx_block['status'])
+        return cdx_block
 
 
 #=================================================================


### PR DESCRIPTION
## Description

If a CDX entry has a status that is an integer instead of a string (which is what ArchiveWeb.page currently generates) then pywb will blow up during replay:

```
Traceback (most recent call last):
  File "/Users/edsummers/Projects/pywb/pywb/warcserver/basewarcserver.py", line 77, in __call__
    result = endpoint(environ, **args)
  File "/Users/edsummers/Projects/pywb/pywb/warcserver/basewarcserver.py", line 46, in post_fullrequest
    return handler(params)
  File "/Users/edsummers/Projects/pywb/pywb/warcserver/handlers.py", line 160, in __call__
    out_headers, resp = loader(cdx, params)
  File "/Users/edsummers/Projects/pywb/pywb/warcserver/resource/responseloader.py", line 37, in __call__
    entry = self.load_resource(cdx, params)
  File "/Users/edsummers/Projects/pywb/pywb/warcserver/resource/responseloader.py", line 214, in load_resource
    if not status or not status.startswith(('2', '4', '5')):
AttributeError: 'int' object has no attribute 'startswith'
```

This commit will guard against that by casting status int values to a str.

## Motivation and Context

It would be useful to be able to unpack a WACZ file created with ArchiveWeb.page (or other tools) and have it playable in pywb by moving the WARC and CDXJ files into place. Currently this is not possible because WACZ uses an int for the CDXJ status, whereas pywb expects it to be a string in multiple places. In the spirit of the robustness principle this change will be lenient in what is accepted in CDXJ files by casting an int status value to a str.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [X] All new and existing tests passed.

