### PR TITLE
Update test docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ To run and install locally you can:
 
 * Install with ``python setup.py install``
 
-* Run tests with ``python setup.py test``
+* Run tests with ``tox`` (you will need to ``pip install tox`` first)
 
 * Run Wayback with ``wayback`` (see docs for info on how to setup collections)
 


### PR DESCRIPTION
## Description

Running the tests with `python setup.py test` does not work due to various version mismatches. However they do run with tox, as they are being run by GitHub actions. This is a small docfix change to alert anyone trying to run the tests that they should use tox.

## Motivation and Context

It's important for contributors to know how to run the tests!

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
