### PR TITLE
Improve replay banner's accessibility

### DIFF
--- a/pywb/static/default_banner.js
+++ b/pywb/static/default_banner.js
@@ -148,6 +148,10 @@ This file is part of pywb, https://github.com/webrecorder/pywb
    * @param {string} bid - The id for the banner
    */
   DefaultBanner.prototype.createBanner = function(bid) {
+    this.header = document.createElement('header');
+    this.header.setAttribute('role', 'banner');
+    this.nav = document.createElement('nav');
+
     this.banner = document.createElement('wb_div', true);
     this.banner.setAttribute('id', bid);
     this.banner.setAttribute('lang', 'en');
@@ -208,8 +212,9 @@ This file is part of pywb, https://github.com/webrecorder/pywb
     }
 
     this.banner.appendChild(ancillaryLinks);
-
-    document.body.insertBefore(this.banner, document.body.firstChild);
+    this.nav.appendChild(this.banner);
+    this.header.appendChild(this.nav);
+    document.body.insertBefore(this.header, document.body.firstChild);
   };
 
   /**


### PR DESCRIPTION
## Description
* Puts banner in header and nav landmark regions
* Adds landmark role of banner to header

## Motivation and Context
The SiteImprove automated accessibility checker flags the replay banner for not following [ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/), specifically concerning landmark regions.  These changes are intended to improve site navigation by screen readers. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
