### PR TITLE
Fix example Docker commands in usage docs

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -95,8 +95,8 @@ add the WARC to a new collection and start pywb:
 
       docker pull webrecorder/pywb
       docker run -e INIT_COLLECTION=my-web-archive -v /pywb-data:/webarchive \
-         -v /path/to:/source webrecorder/pywb wb-manager add default /path/to/my_warc.warc.gz
-      docker run -p 8080:8080 -v /pywb-data/:/webarchive wayback
+         -v /path/to:/source webrecorder/pywb wb-manager add default /source/my_warc.warc.gz
+      docker run -p 8080:8080 -v /pywb-data/:/webarchive webrecorder/pywb wayback
 
 This example is equivalent to the non-Docker example above.
 


### PR DESCRIPTION
## Description

This PR makes two modifications to the example Docker commands in pywb's usage documentation:
* Adding the repository name to the example `wayback` command
* Updating the example `wb-manager add` command to reflect the path to the WARC file inside the Docker volume rather than on the Docker host

## Motivation and Context

These fixes will make it easier for users to run Dockerized pywb without needing to debug why the provided sample commands aren't working.

## Types of changes

- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix

## Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
