### PR TITLE
Prevent jinja2 from escaping HTML markup in collection metadata

### DIFF
--- a/pywb/templates/search.html
+++ b/pywb/templates/search.html
@@ -23,7 +23,9 @@ window.wb_prefix = "{{ wb_prefix }}";
             <div class="col-12">
                 <label for="search-url" class="lead" aria-label="Search For Col">
                     {% set coll_title = metadata.title if metadata and metadata.title else coll %}
-                    {% trans %}Search the {{ coll_title }} collection by url:{% endtrans %}
+                    {% autoescape false %}
+                    {% trans %}Search the {{ coll_title }} collection by url: {% endtrans %}
+                    {% endautoescape %}
                 </label>
                 <input aria-label="url" aria-required="true" class="form-control form-control-lg" id="search-url"
                        name="search" placeholder="{{ _('Enter a URL to search for') }}"
@@ -170,7 +172,7 @@ window.wb_prefix = "{{ wb_prefix }}";
                              id="collection-metadata-{{ key }}" role="tabpanel">
                             <div class="card inherit-height">
                                 <div class="card-body">
-                                    {{ val }}
+                                    {{ val | safe }}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Description

This PR adds jinja2 `safe` filters to metadata values and an `{% autoescape false %}` block to the collection title in the search template to prevent HTML markup in collection metadata from being escaped.

## Motivation and Context

Connected to https://github.com/webrecorder/pywb/issues/727

This fixes a regression in more recent versions of pywb which was reported by users.

## Screenshots (if appropriate):

### Before

(copied from linked issue)

![image](https://user-images.githubusercontent.com/6758804/181680293-21b36425-355f-4ec3-8f80-cbcf77effb56.png)

### After

<img width="1023" alt="Screen Shot 2022-07-29 at 12 00 10 AM" src="https://user-images.githubusercontent.com/6758804/181680336-b813622a-183c-4781-8452-d33eaca64715.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [X] All new and existing tests passed.
