### PR TITLE
Import UserAgent from werkzeug.user_agent rather than deprecated module

### DIFF
--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -20,7 +20,7 @@ from pywb.rewrite.rewrite_js_workers import JSWorkerRewriter
 from pywb import DEFAULT_RULES_FILE
 
 import copy
-from werkzeug.useragents import UserAgent
+from werkzeug.user_agent import UserAgent
 
 
 # ============================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jinja2<3.0.0
 surt>=0.3.1
 brotlipy
 pyyaml
-werkzeug
+werkzeug>=2.0.3
 webencodings
 gevent==20.9.0
 webassets==0.12.1


### PR DESCRIPTION
## Description

Werkzeug deprecated the `useragents` module in 2.0.x and removed it entirely in 2.1.x in favor of `werkzeug.user_agent`. This commit modifies the `rewriterapp` to import `UserAgent` from `user_agent` and sets requirements.txt to ensure versions of werkzeug prior to 2.0.x won't be used.

## Motivation and Context

Connected to #745 

The deprecation of `werkzeug.useragents` is causing a 500 Internal Server Error in the wayback machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
