### PR TITLE
Revisit headers load fix

### DIFF
--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.7'
+__version__ = '2.6.8'
 
 if __name__ == '__main__':
     print(__version__)

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -215,23 +215,25 @@ class WARCPathLoader(DefaultResolverMixin, BaseLoader):
             except:
                 orig_size = 0
 
+            http_headers = headers.http_headers or payload.http_headers
+
             # if status is not set and not, 2xx, 4xx, 5xx
             # go through self-redirect check just in case
             if not status or not status.startswith(('2', '4', '5')):
                 try:
                     self.raise_on_self_redirect(params, cdx,
-                                                headers.http_headers.get_statuscode(),
-                                                headers.http_headers.get_header('Location'))
+                                                http_headers.get_statuscode(),
+                                                http_headers.get_header('Location'))
                 except LiveResourceException:
                     no_except_close(headers.raw_stream)
                     no_except_close(payload.raw_stream)
                     raise
 
-            http_headers_buff = headers.http_headers and headers.http_headers.to_bytes()
+            http_headers_buff = http_headers and http_headers.to_bytes()
 
             # if new http_headers_buff is different length,
             # attempt to adjust content-length on the WARC record
-            if orig_size and len(http_headers_buff) != orig_size:
+            if http_headers and orig_size and len(http_headers_buff) != orig_size:
                 orig_cl = payload.rec_headers.get_header('Content-Length')
                 if orig_cl:
                     new_cl = int(orig_cl) + (len(http_headers_buff) - orig_size)

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -172,7 +172,7 @@ class WARCPathLoader(DefaultResolverMixin, BaseLoader):
         self.resolvers = self.make_resolvers(self.paths)
 
         self.resolve_loader = ResolvingLoader(self.resolvers,
-                                              no_record_parse=True)
+                                              no_record_parse=False)
 
         self.headers_parser = StatusAndHeadersParser([], verify=False)
 
@@ -206,36 +206,36 @@ class WARCPathLoader(DefaultResolverMixin, BaseLoader):
                                                       local_index_query))
 
         http_headers_buff = None
+
         if payload.rec_type in ('response', 'revisit'):
             status = cdx.get('status')
+
+            try:
+                orig_size = payload.raw_stream.tell()
+            except:
+                orig_size = 0
 
             # if status is not set and not, 2xx, 4xx, 5xx
             # go through self-redirect check just in case
             if not status or not status.startswith(('2', '4', '5')):
-                http_headers = self.headers_parser.parse(payload.raw_stream)
-                try:
-                    orig_size = payload.raw_stream.tell()
-                except:
-                    orig_size = 0
-
                 try:
                     self.raise_on_self_redirect(params, cdx,
-                                                http_headers.get_statuscode(),
-                                                http_headers.get_header('Location'))
+                                                headers.http_headers.get_statuscode(),
+                                                headers.http_headers.get_header('Location'))
                 except LiveResourceException:
                     no_except_close(headers.raw_stream)
                     no_except_close(payload.raw_stream)
                     raise
 
-                http_headers_buff = http_headers.to_bytes()
+            http_headers_buff = headers.http_headers and headers.http_headers.to_bytes()
 
-                # if new http_headers_buff is different length,
-                # attempt to adjust content-length on the WARC record
-                if orig_size and len(http_headers_buff) != orig_size:
-                    orig_cl = payload.rec_headers.get_header('Content-Length')
-                    if orig_cl:
-                        new_cl = int(orig_cl) + (len(http_headers_buff) - orig_size)
-                        payload.rec_headers.replace_header('Content-Length', str(new_cl))
+            # if new http_headers_buff is different length,
+            # attempt to adjust content-length on the WARC record
+            if orig_size and len(http_headers_buff) != orig_size:
+                orig_cl = payload.rec_headers.get_header('Content-Length')
+                if orig_cl:
+                    new_cl = int(orig_cl) + (len(http_headers_buff) - orig_size)
+                    payload.rec_headers.replace_header('Content-Length', str(new_cl))
 
         warc_headers = payload.rec_headers
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,13 +102,15 @@ class TestWbIntegration(BaseConfigTest):
         assert not resp.headers.get('Content-Length')
 
     def test_replay_content_head_non_zero_content_length_match(self):
-        resp = self.testapp.get('/pywb/id_/http://www.iana.org/_js/2013.1/jquery.js', status=200)
+        resp = self.testapp.get('/pywb/20140126200625id_/http://www.iana.org/_js/2013.1/jquery.js', status=200)
         length = resp.content_length
+        print('length', length)
 
         # Content-Length included if non-zero
-        resp = self.testapp.head('/pywb/id_/http://www.iana.org/_js/2013.1/jquery.js', status=200)
+        resp = self.testapp.head('/pywb/20140126200625id_/http://www.iana.org/_js/2013.1/jquery.js', status=200)
 
         #assert resp.headers['Content-Length'] == length
+        print('length', resp.content_length)
         assert resp.content_length == length
 
     def test_replay_content(self, fmod):

--- a/tests/test_redirect_revisits.py
+++ b/tests/test_redirect_revisits.py
@@ -1,0 +1,146 @@
+
+from io import BytesIO
+import os
+
+from warcio import WARCWriter, StatusAndHeaders
+from pywb.manager.manager import main as wb_manager
+
+from .base_config_test import BaseConfigTest, CollsDirMixin, fmod
+
+
+# ============================================================================
+class TestRevisits(CollsDirMixin, BaseConfigTest):
+    @classmethod
+    def setup_class(cls):
+        super(TestRevisits, cls).setup_class('config_test.yaml')
+
+
+    def create_revisit_record(self, url, date, headers, refers_to_uri, refers_to_date):
+        http_headers = StatusAndHeaders(
+            "301 Permanent Redirect", headers, protocol="HTTP/1.0"
+        )
+
+        return self.writer.create_revisit_record(
+            url,
+            digest="sha1:B6QJ6BNJ3R4B23XXMRKZKHLPGJY2VE4O",
+            refers_to_uri=refers_to_uri,
+            refers_to_date=refers_to_date,
+            warc_headers_dict={"WARC-Date": date},
+            http_headers=http_headers,
+        )
+
+
+    def create_response_record(self, url, date, headers, payload):
+        http_headers = StatusAndHeaders(
+            "301 Permanent Redirect", headers, protocol="HTTP/1.0"
+        )
+
+        return self.writer.create_warc_record(
+            url,
+            record_type="response",
+            http_headers=http_headers,
+            payload=BytesIO(payload),
+            warc_headers_dict={"WARC-Date": date},
+            length=len(payload),
+        )
+
+    def create(self):
+        payload = b"some\ntext"
+
+        # record 1
+        self.writer.write_record(
+            self.create_response_record(
+                "http://example.com/orig-1",
+                "2020-01-01T00:00:00Z",
+                [
+                    ("Content-Type", 'text/plain; charset="UTF-8"'),
+                    ("Location", "https://example.com/redirect-1"),
+                    ("Content-Length", str(len(payload))),
+                    ("Custom", "1"),
+                ],
+                payload,
+            )
+        )
+
+        # record 2
+        self.writer.write_record(
+            self.create_response_record(
+                "http://example.com/orig-2",
+                "2020-01-01T00:00:00Z",
+                [
+                    ("Content-Type", 'text/plain; charset="UTF-8"'),
+                    ("Location", "https://example.com/redirect-2"),
+                    ("Content-Length", str(len(payload))),
+                    ("Custom", "2"),
+                ],
+                payload,
+            )
+        )
+
+        # record 3
+        self.writer.write_record(
+            self.create_revisit_record(
+                "http://example.com/orig-2",
+                "2022-01-01T00:00:00Z",
+                [
+                    ("Content-Type", 'text/plain; charset="UTF-8"'),
+                    ("Location", "https://example.com/redirect-3"),
+                    ("Content-Length", str(len(payload))),
+                    ("Custom", "3"),
+                ],
+                refers_to_uri="http://example.com/orig-1",
+                refers_to_date="2020-01-01T00:00:00Z",
+            )
+        )
+
+        # record 4
+        self.writer.write_record(
+            self.create_revisit_record(
+                "http://example.com/",
+                "2022-01-01T00:00:00Z",
+                [
+                    ("Content-Type", 'text/plain; charset="UTF-8"'),
+                    ("Location", "https://example.com/redirect-4"),
+                    ("Content-Length", str(len(payload))),
+                    ("Custom", "4"),
+                ],
+                refers_to_uri="http://example.com/orig-2",
+                refers_to_date="2020-01-01T00:00:00Z",
+            )
+        )
+
+    def test_init(self):
+        filename = os.path.join(self.root_dir, 'redir.warc.gz')
+        with open(filename, 'wb') as fh:
+            self.writer = WARCWriter(fh, gzip=True)
+            self.create()
+
+        wb_manager(['init', 'revisits'])
+
+        wb_manager(['add', 'revisits', filename])
+
+        assert os.path.isfile(os.path.join(self.root_dir, self.COLLS_DIR, 'revisits', 'indexes', 'index.cdxj'))
+
+    def test_different_url_revisit_orig_headers(self, fmod):
+        res = self.get('/revisits/20220101{0}/http://example.com/', fmod, status=301)
+        assert res.headers["Custom"] == "4"
+        assert res.headers["Location"].endswith("/20220101{0}/https://example.com/redirect-4".format(fmod))
+        assert res.text == 'some\ntext'
+
+    def test_different_url_revisit_and_response(self, fmod):
+        res = self.get('/revisits/20200101{0}/http://example.com/orig-2', fmod, status=301)
+        assert res.headers["Custom"] == "2"
+        assert res.headers["Location"].endswith("/20200101{0}/https://example.com/redirect-2".format(fmod))
+        assert res.text == 'some\ntext'
+
+        res = self.get('/revisits/20220101{0}/http://example.com/orig-2', fmod, status=301)
+        assert res.headers["Custom"] == "3"
+        assert res.headers["Location"].endswith("/20220101{0}/https://example.com/redirect-3".format(fmod))
+        assert res.text == 'some\ntext'
+
+    def test_orig(self, fmod):
+        res = self.get('/revisits/20200101{0}/http://example.com/orig-1', fmod, status=301)
+        assert res.headers["Custom"] == "1"
+        assert res.headers["Location"].endswith("/20200101{0}/https://example.com/redirect-1".format(fmod))
+        assert res.text == 'some\ntext'
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
Revisit records may contain HTTP headers, or they may contain no headers. If they do contain headers, the replay should use the HTTP headers from the revisit record, and they payload from the original record referenced by the revisit.
Unfortunately, this was not working (possibly ever?) as expected!
It appears that pywb was always using the HTTP headers from the original record.
Generally, this is fine, except in the case where the revisit record is of a redirect, and the HTTP headers have changed between the revisit and the original (while the payload is the same, and generally ignored).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
This fixes an issue originally found in sul-dlss/was-pywb#64

Added test case which I believe replicates this issue.
cc: @edsu 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
