### PR TITLE
Enable translation for the remaining strings on the search results page

### DIFF
--- a/pywb/static/query.js
+++ b/pywb/static/query.js
@@ -371,16 +371,13 @@ RenderCalendar.prototype.createContainers = function() {
         },
         { tag: 'textNode', value: ' ' },
         {
-          tag: 'b',
-          child: {
-            tag: 'textNode',
-            value: '',
-            ref: function(refToElem) {
-              renderCal.containers.versionsTextNode = refToElem;
-            }
+          tag: 'textNode',
+          value: '',
+          ref: function(refToElem) {
+            renderCal.containers.versionsTextNode = refToElem;
           }
         },
-        { tag: 'textNode', value: ' of ' + this.queryInfo.url }
+        { tag: 'b', innerText: ' ' + this.queryInfo.url }
       ]
     });
     // create the row that will hold the results of the regular query
@@ -440,11 +437,11 @@ RenderCalendar.prototype.createContainers = function() {
   var forElems;
 
   if (this.queryInfo.searchParams.matchType) {
-    forString = ' for matching ';
+    forString = ' ' + this.text.matching + ' ';
     forElems = [
       { tag: 'b', innerText: this.queryInfo.url },
-      { tag: 'textNode', value: ' by ' },
-      { tag: 'b', innerText: this.queryInfo.searchParams.matchType }
+      { tag: 'textNode', value: ' ' + this.text.by + ' ' },
+      { tag: 'b', innerText: this.text.types[this.queryInfo.searchParams.matchType] }
     ];
   } else {
     forElems = [{ tag: 'b', innerText: this.queryInfo.url }];
@@ -463,23 +460,21 @@ RenderCalendar.prototype.createContainers = function() {
         },
         {
           tag: 'b',
-          children: [
-            {
-              tag: 'textNode',
-              value: '',
-              ref: function(refToElem) {
-                renderCal.containers.countTextNode = refToElem;
-              }
-            },
-            { tag: 'textNode', value: ' ' },
-            {
-              tag: 'textNode',
-              value: '',
-              ref: function(refToElem) {
-                renderCal.containers.versionsTextNode = refToElem;
-              }
+          child: {
+            tag: 'textNode',
+            value: '',
+            ref: function(refToElem) {
+              renderCal.containers.countTextNode = refToElem;
             }
-          ]
+          }
+        },
+        { tag: 'textNode', value: ' ' },
+        {
+          tag: 'textNode',
+          value: '',
+          ref: function(refToElem) {
+            renderCal.containers.versionsTextNode = refToElem;
+          }
         },
         { tag: 'textNode', value: forString }
       ].concat(forElems)
@@ -614,13 +609,13 @@ RenderCalendar.prototype.renderAdvancedSearchPart = function(cdxObj) {
   if (cdxObj.mime) {
     displayedInfo.push({
       tag: 'small',
-      innerText: 'Mime Type: ' + cdxObj.mime
+      innerText: this.text.mimeType + cdxObj.mime
     });
   }
   if (cdxObj.status) {
     displayedInfo.push({
       tag: 'small',
-      innerText: 'HTTP Status: ' + cdxObj.status
+      innerText: this.text.httpStatus + cdxObj.status
     });
   }
   displayedInfo.push({
@@ -1062,7 +1057,7 @@ RenderCalendar.prototype.tsToDate = function(ts, is_gmt) {
     '-00:00';
 
   var date = new Date(datestr);
-  return is_gmt ? date.toGMTString() : date.toLocaleString();
+  return is_gmt ? date.toGMTString() : date.toLocaleString(document.documentElement.lang);
 };
 
 /**

--- a/pywb/static/query.js
+++ b/pywb/static/query.js
@@ -780,6 +780,11 @@ RenderCalendar.prototype.addRegYearMonthDayListItem = function(
        a[href="replay url"]
        span[id=count_ts].badge.badge-info.badge-pill.float-right
    */
+    const options = {
+      dateStyle: 'long',
+      timeStyle: 'medium',
+    };
+    var dateTimeString = this.tsToDate(cdxObj.timestamp, false, options);
     this.createAndAddElementTo(ymlDL, {
       tag: 'li',
       className: 'list-group-item',
@@ -790,17 +795,7 @@ RenderCalendar.prototype.addRegYearMonthDayListItem = function(
             href: this.prefix + cdxObj.timestamp + '/' + cdxObj.url,
             target: '_blank'
           },
-          innerText:
-            timeInfo.month +
-            ' ' +
-            timeInfo.day +
-            this.dateOrdinal(timeInfo.day) +
-            ', ' +
-            timeInfo.year +
-            ' ' +
-            ' at ' +
-            timeInfo.time +
-            '  '
+          innerText: dateTimeString
         },
         {
           tag: 'span',
@@ -1016,31 +1011,13 @@ RenderCalendar.prototype.displayYearMonthDaysListId = function(year, month) {
 };
 
 /**
- * Returns a numbers ordinal string
- * @param {number} d - The number to receive the ordinal string for
- * @returns {string}
- */
-RenderCalendar.prototype.dateOrdinal = function(d) {
-  if (d > 3 && d < 21) return 'th';
-  switch (d % 10) {
-    case 1:
-      return 'st';
-    case 2:
-      return 'nd';
-    case 3:
-      return 'rd';
-    default:
-      return 'th';
-  }
-};
-
-/**
  * Converts the supplied timestamp to either a local data string or a gmt string (if is_gmt is true)
  * @param {string} ts - The timestamp to be converted to a string
  * @param {boolean} [is_gmt] - Should the timestamp be converted to a gmt string
+ * @param {Object} [options] - String formatting options
  * @returns {string}
  */
-RenderCalendar.prototype.tsToDate = function(ts, is_gmt) {
+RenderCalendar.prototype.tsToDate = function(ts, is_gmt, options) {
   if (ts.length < 14) return ts;
   var datestr =
     ts.substring(0, 4) +
@@ -1057,7 +1034,7 @@ RenderCalendar.prototype.tsToDate = function(ts, is_gmt) {
     '-00:00';
 
   var date = new Date(datestr);
-  return is_gmt ? date.toGMTString() : date.toLocaleString(document.documentElement.lang);
+  return is_gmt ? date.toUTCString() : date.toLocaleString(document.documentElement.lang, options);
 };
 
 /**

--- a/pywb/templates/query.html
+++ b/pywb/templates/query.html
@@ -38,12 +38,21 @@
        '11': "{{ _('November') }}",
        '12': "{{ _('December') }}",
       },
-      version: "{{ _('capture') }}",
-      versions: "{{ _('captures') }}",
+      version: "{{ _('capture of') }}",
+      versions: "{{ _('captures of') }}",
       result: "{{ _('result') }}",
       results: "{{ _('results') }}",
+      matching: "{{ _('for matching') }}",
+      by: "{{ _('by') }}",
       viewAllCaptures: "{{ _('View All Captures') }}",
       dateTime: "{{ _('Date Time: ') }}",
+      mimeType: "{{ _('Mime Type: ') }}",
+      httpStatus: "{{ _('HTTP Status: ') }}",
+      types: {
+        'prefix': "{{ _('prefix') }}",
+        'host': "{{ _('host') }}",
+        'domain': "{{ _('domain') }}",
+      },
     };
 
   var renderCal = new RenderCalendar({ prefix: "{{ prefix }}", staticPrefix: "{{ static_prefix }}", text: text });


### PR DESCRIPTION
A few strings on the search results pages were hard coded an not enclosed with the translation function which gave the page a half translated impression.

## Description

 * add the remaining strings to the `text` dict in `query.html`
     * `for matching` / `captures of`
     * `by`
     * `Mime Type`
     * `HTTP Status`
 * replace the occurrences of those strings with the corresponding dict element in `query.js`
 * tidy up the usage of bold in `query.js` for consistency
 * use the `tsToDate()` function also for the timestamps for search results without matchType
 * use the `document.documentElement.lang` parameter to decide how to localize the timestamps in `query.js`

The last item means that if the user has chosen a language for the page the timestamps will be formatted accordingly; otherwise the locale of the browser will control the formatting. It is totally feasible to use different language settings for the browser and the content.

## Motivation and Context

All other pages can be completely localized. This was as far as I can tell the remaining missing strings.

## Screenshots (if appropriate):
Before:
![2022-08-18-093945_1049x219_scrot](https://user-images.githubusercontent.com/4865723/185338007-83b75fa5-1ee3-4b54-b252-7e9accbdce18.png)

After:
![2022-08-18-091951_1048x216_scrot](https://user-images.githubusercontent.com/4865723/185337044-77625a04-97e5-4964-830a-99dafc4a3ea8.png)

(The National Library logo and the "Logga in" link are local customizations and not part of this change.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.

The `python setup.py test` command fails early with a versioning conflict when running locally - with or without this change. I appears that the test subsystem does not care about version limitations in requirements.txt when installing python modules. As this is a non-functional change, there probably aren't any test for it anyway.

Trying to use localized ordinal suffixes for dates is a hard problem as there is no built in support for it in Javascript which I guess is why most timestamp-to-string implementations don't use ordinal suffixes.