### PR TITLE
tests run improvements: update from python setup.py test -> tox 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,10 @@ The 2.x release included a major overhaul of pywb and introduces many new featur
 Please see the `full documentation <https://pywb.readthedocs.org>`_ for more detailed info on all these features.
 
 
-Installation
-------------
+Installation for Deployment
+---------------------------
+
+To install pywb for usage, you can use:
 
 ```shell
 pip install pywb
@@ -64,16 +66,25 @@ pip install pywb
 
 Note: depending on your Python installation, you may have to use `pip3` instead of `pip`.
 
-To install, test and build docs locally you can:
 
-* Install with ``python setup.py install``
+Installation from local copy
+----------------------------
 
-* Run tests with ``python setup.py test``
+```shell
+git clone https://github.com/webrecorder/pywb
+```
 
-* Run Wayback with ``wayback`` (see docs for info on how to setup collections)
+To install from a locally cloned copy, install with ``pip install -e .`` or ``python setup.py install``.
 
-* Build docs locally with:  ``cd docs; make html``. (The docs will be built in ``./_build/html/index.html``)
+To run tests, we recommend installing ``pip install tox tox-current-env`` and then running ``tox --current-env`` to test in your current Python environment.
 
+To Build docs locally, run:  ``cd docs; make html``. (The docs will be built in ``./_build/html/index.html``)
+
+
+Running
+-------
+
+After installation, you can run ``pywb`` or ``wayback``.
 
 Consult the local or `online docs <https://pywb.readthedocs.org>`_ for latest usage and configuration details.
 

--- a/pywb/manager/locmanager.py
+++ b/pywb/manager/locmanager.py
@@ -2,10 +2,14 @@ import os
 import os.path
 import shutil
 
-from babel.messages.frontend import CommandLineInterface
+try:
+    from babel.messages.frontend import CommandLineInterface
 
-from translate.convert.po2csv import main as po2csv
-from translate.convert.csv2po import main as csv2po
+    from translate.convert.po2csv import main as po2csv
+    from translate.convert.csv2po import main as csv2po
+    loc_avail = True
+except:
+    loc_avail = False
 
 
 ROOT_DIR = 'i18n'

--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -448,12 +448,7 @@ Create manage file based web archive collections
     acl.set_defaults(func=do_acl)
 
     # LOC
-    loc_avail = False
-    try:
-        from pywb.manager.locmanager import LocManager
-        loc_avail = True
-    except:
-        pass
+    from pywb.manager.locmanager import LocManager, loc_avail
 
     def do_loc(r):
         if not loc_avail:

--- a/setup.py
+++ b/setup.py
@@ -113,17 +113,7 @@ setup(
             "translate_toolkit"
         ],
     },
-    tests_require=[
-        'pytest',
-        'WebTest',
-        'pytest-cov',
-        'mock',
-        'urllib3',
-        'werkzeug',
-        'httpbin==0.5.0',
-        'ujson',
-        'lxml'
-    ],
+    tests_require=load_requirements("test_requirements.txt"),
     cmdclass={'test': PyTest},
     test_suite='',
     entry_points="""

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,6 @@ WebTest
 pytest-cov
 mock
 urllib3
-werkzeug
 httpbin==0.5.0
 flask<2.0
 ujson

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,10 @@
+pytest
+WebTest
+pytest-cov
+mock
+urllib3
+werkzeug
+httpbin==0.5.0
+flask<2.0
+ujson
+lxml

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1,4 +1,5 @@
 from .base_config_test import BaseConfigTest
+import pytest
 
 
 # ============================================================================
@@ -6,6 +7,8 @@ class TestLocales(BaseConfigTest):
     @classmethod
     def setup_class(cls):
         super(TestLocales, cls).setup_class('config_test_loc.yaml')
+        pytest.importorskip('babel')
+        pytest.importorskip('translate_toolkit')
 
     def test_locale_en_home(self):
         res = self.testapp.get('/en/')

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ testpaths =
     tests
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
@@ -12,20 +12,11 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py39
 
 [testenv]
 deps =
-    pytest
-    pytest-cov
-    coverage
-    WebTest
-    fakeredis<1.0
-    mock
-    urllib3
-    werkzeug
-    httpbin==0.5.0
-    ujson
-    lxml
+    -rtest_requirements.txt
     -rrequirements.txt
     -rextra_requirements.txt
 commands =


### PR DESCRIPTION
- Since `python setup.py test` is now obsolete, recommend running tests locally with tox
- move test requirements to test_requirements.txt to share between setup.py and tox.ini
- Update README to recommend using 'tox --current-env' for running tests locally,
- add py3.10 to tox environments
- ensure test run without i18n extras installed
- replaces #741
