### PR TITLE
Add ir_ modifier

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -524,7 +524,7 @@ class RewriteInfo(object):
         if not self.text_type:
             return False
 
-        if self.url_rewriter.wburl.mod == 'id_':
+        if self.is_identity():
             return False
 
         if self.url_rewriter.rewrite_opts.get('is_ajax'):
@@ -537,9 +537,11 @@ class RewriteInfo(object):
 
         return True
 
+    def is_identity(self):
+        return self.url_rewriter.wburl.mod in ('id_', 'ir_')
+
     def is_url_rw(self):
         if self.url_rewriter.wburl.mod in ('id_', 'bn_', 'wkrf_'):
             return False
 
         return True
-

--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -103,6 +103,7 @@ class DefaultRewriter(BaseContentRewriter):
         self.all_rewriters = copy.copy(self.DEFAULT_REWRITERS)
 
         self.add_prefer_mod('raw', 'id_')
+        self.add_prefer_mod('raw', 'ir_')
         self.add_prefer_mod('banner-only', 'bn_')
         self.add_prefer_mod('rewritten', replay_mod)
 

--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -102,8 +102,8 @@ class DefaultRewriter(BaseContentRewriter):
         super(DefaultRewriter, self).__init__(rules_file, replay_mod)
         self.all_rewriters = copy.copy(self.DEFAULT_REWRITERS)
 
-        self.add_prefer_mod('raw', 'id_')
         self.add_prefer_mod('raw', 'ir_')
+        self.add_prefer_mod('raw', 'id_')
         self.add_prefer_mod('banner-only', 'bn_')
         self.add_prefer_mod('rewritten', replay_mod)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -138,7 +138,19 @@ class TestWbIntegration(BaseConfigTest):
 
     def test_replay_redirect(self, fmod):
         resp = self.get('/pywb/2014{0}/http://www.iana.org/domains/example', fmod)
-        assert resp.headers['Location'].startswith('/pywb/2014{0}/'.format(fmod))
+        assert resp.headers['Location'] == '/pywb/2014{0}/http://www.iana.org/domains/reserved'.format(fmod)
+        assert resp.status_code == 302
+
+    def test_replay_redirect_id(self):
+        resp = self.get('/pywb/2014id_/http://www.iana.org/domains/example', fmod)
+        print(resp.headers['Location'])
+        assert resp.headers['Location'] == '/domains/reserved'
+        assert resp.status_code == 302
+
+    def test_replay_redirect_ir(self):
+        resp = self.get('/pywb/2014ir_/http://www.iana.org/domains/example', fmod)
+        print(resp.headers['Location'])
+        assert resp.headers['Location'] == '/pywb/2014ir_/http://www.iana.org/domains/reserved'
         assert resp.status_code == 302
 
     def test_replay_fuzzy_1(self, fmod):
@@ -215,6 +227,17 @@ class TestWbIntegration(BaseConfigTest):
 
     def test_replay_identity_1(self):
         resp = self.testapp.get('/pywb/20140127171251id_/http://example.com/')
+
+        # no wb header insertion
+        assert 'wombat.js' not in resp.text
+
+        assert resp.content_length == 1270, resp.content_length
+
+        # original unrewritten url present
+        assert '"http://www.iana.org/domains/example"' in resp.text
+
+    def test_replay_identity_1_ir(self):
+        resp = self.testapp.get('/pywb/20140127171251ir_/http://example.com/')
 
         # no wb header insertion
         assert 'wombat.js' not in resp.text


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `ir_` modifier serves content w/o rewriting, similar to `id_`, but does rewrite Location headers such that they can be followed, especially when loading in the browser.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
To support loading resources w/o rewriting, while still following redirects.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
