### PR TITLE
tests options: add PYWB_NO_VERIFY_SSL env var for tests to avoid fail…

### DIFF
--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -22,6 +22,10 @@ import requests
 
 import re
 import logging
+import os
+
+
+no_verify = os.environ.get("PYWB_NO_VERIFY_SSL")
 
 
 #=============================================================================
@@ -46,6 +50,8 @@ class BaseIndexSource(object):
         self.sesh = requests.Session()
         self.sesh.mount('http://', adapter)
         self.sesh.mount('https://', adapter)
+        if no_verify:
+            self.sesh.verify = False
 
 
 #=============================================================================

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,10 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py39
+    3.10: py310
 
 [testenv]
+setenv = PYWB_NO_VERIFY_SSL = 1
 deps =
     -rtest_requirements.txt
     -rrequirements.txt


### PR DESCRIPTION
To help with testing a website with expired cert, add `PYWB_NO_VERIFY_SSL=1` support, which will then use requests w/o checking the cert. Mostly useful for testing.