### PR TITLE
rewriting fix: twitter video in embedded tweets

### DIFF
--- a/pywb/rewrite/rewrite_dash.py
+++ b/pywb/rewrite/rewrite_dash.py
@@ -90,17 +90,25 @@ def rewrite_tw_dash(string, *args):
     try:
         best_variant = None
         best_bitrate = 0
+        best_src = ""
         max_bitrate = 5000000
 
         data = json.loads(string)
         for variant in data["variants"]:
-            if variant["content_type"] != "video/mp4":
+            if (("content_type" in variant and variant["content_type"] != "video/mp4") or
+                ("type" in variant and variant["type"] != "video/mp4")):
                 continue
 
             bitrate = variant.get("bitrate")
+            src = variant.get("src")
+
             if bitrate and bitrate > best_bitrate and bitrate <= max_bitrate:
                 best_variant = variant
                 best_bitrate = bitrate
+            # just compare src strings with dimensions
+            elif src and src > best_src:
+                best_variant = variant
+                best_src = src
 
         if best_variant:
             data["variants"] = [best_variant]

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -61,6 +61,7 @@ rules:
 
     # twitter rules
     #=================================================================
+
     - url_prefix: 'com,twitter)/i/profiles/show/'
 
       fuzzy_lookup: '/profiles/show/.*with_replies\?.*(max_id=[^&]+)'
@@ -84,6 +85,14 @@ rules:
               function: 'pywb.rewrite.rewrite_dash:rewrite_tw_dash'
 
  
+    - url_prefix: ['com,twimg,syndication,cdn)/tweet-result']
+
+      rewrite:
+        js_regexs:
+            - match: 'video":(.*?viewCount":\d+})'
+              group: 1
+              function: 'pywb.rewrite.rewrite_dash:rewrite_tw_dash'
+
      
 
     # facebook rules


### PR DESCRIPTION
## Description
Improve twitter rewrite to also use mp4 for videos in twitter embed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Partial fix to embedded tweets, as described in webrecorder/browsertrix-crawler#160

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
