### PR TITLE
Add docker build to arm64 platform

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,10 @@ jobs:
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
Adds armv8/arm64/aarch64 platform for buildx to build against and publish to Docker hub.

Has been successfully built and tested [here](https://hub.docker.com/r/communityfirst/pywb).