### PR TITLE
Add arm64 platform support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,5 +38,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
## Description
Adds arm64 to the Docker Hub Github Action. Has been tested at [communityfirst/pywb](https://hub.docker.com/r/communityfirst/pywb).

## Motivation and Context
We need to run this on arm64 devices: Pi 4s

## Types of changes
- [x] New feature: support for arm64

## Checklist:
- [x] All new and existing tests passed.
