### PR TITLE
feat: regex substitution on surt rules match

### DIFF
--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -110,7 +110,7 @@ rules:
 
       fuzzy_lookup:
         match: '("(?:cursor|cursorindex)":["\d\w]+)'
-        find_all: true
+        re_type: findall
 
     - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/profiletimeline'
       fuzzy_lookup: 'com,facebook\)/.*[?&](__adt=[^&]+).*[&]data=(?:.*?(?:[&]|(profile_id|pagelet_token)[^,]+))'
@@ -175,7 +175,7 @@ rules:
 
       fuzzy_lookup:
         match: '("q[\d]+":|after:\\"[^"]+)'
-        find_all: true
+        re_type: findall
 
     - url_prefix: 'com,facebook)/pages_reaction_units/more'
 
@@ -537,6 +537,12 @@ rules:
 
       rewrite:
         js_rewrite_location: urls
+
+    - url_prefix: 'com,example)/matched'
+      fuzzy_lookup:
+        re_type: sub
+        match: 'matched'
+        replace: 'replaced'          
 
     # all domain rules -- fallback to this dataset
     #=================================================================

--- a/pywb/warcserver/index/test/test_fuzzymatcher.py
+++ b/pywb/warcserver/index/test/test_fuzzymatcher.py
@@ -234,3 +234,10 @@ class TestFuzzy(object):
         params = self.get_params(url, actual_url, mime='application/x-shockwave-flash')
         cdx_iter, errs = self.fuzzy(self.source, params)
         assert list(cdx_iter) == []
+
+    def test_fuzzy_sub_replacement(self):
+        url = 'https://example.com/matched'
+        actual_url = 'https://example.com/replaced'
+        params = self.get_params(url, actual_url)
+        cdx_iter, errs = self.fuzzy(self.source, params)
+        assert list(cdx_iter) == self.get_expected(actual_url)


### PR DESCRIPTION
## Description
substituion functionality already exists on a global level for matched rules but this causes issues when rule sets conflict in the desired outcome. This change enables setting regex substitution at the rule level to avoid these conflicts.

The only change to existing functionality is related to the `find_all` parameter moving to be an options in the `re_type` parameter. I've marked this down as a potentially breaking change as it may impact end users custom rule set, the default rules in the `rules.yaml` have been updated.

## Motivation and Context
We have experienced a number of issue that the rules.yaml functionality would resolve but due to substitutions being linked to the more global `url_normalize` functionality we couldn't make use of it fully.

An example issue this would resolve is #694. For this example a ruleset could be configured as below meaning that the `;jsession=foo` string is removed but the query parameters or any additional path data is retained.
```
    - url_prefix: uk,gov,wales,new)/
      fuzzy_lookup: 
        re_type: sub
        match: ';jsessionid=[0-9A-Z]{32}'
        replace: ''
```
In more complex circumstances match groups could be utilised to build the required url.

## Screenshots (if appropriate):

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
