### PR TITLE
[#795] Show error when adding duplicate warc file

### DIFF
--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -123,6 +123,10 @@ directory structure expected by pywb
         full_paths = []
         for filename in warcs:
             filename = os.path.abspath(filename)
+
+            if os.path.exists(os.path.join(self.archive_dir, os.path.basename(filename))):
+                raise IOError(f'Warc {filename} already exists')
+
             shutil.copy2(filename, self.archive_dir)
             full_paths.append(os.path.join(self.archive_dir, filename))
             logging.info('Copied ' + filename + ' to ' + self.archive_dir)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Show an error when adding a warc file that has the same filename as an existing file in the collection and do not overwrite the existing file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

See #795 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
