### PR TITLE
Modify search template buttons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ pywb 2.7.3 changelist
 (In progress)
 
 * Catch warcio exceptions when indexing CDX by @oskarhek
-oskarhek 
 * Add ui.logo_home_url as config.yaml option
 * wb-manager: Show error when adding duplicate warc files by @kuechensofa
+* Improve search template and add help text by @krakan
 
 pywb 2.7.2 changelist
 ~~~~~~~~~~~~~~~~~~~~~

--- a/pywb/static/search.js
+++ b/pywb/static/search.js
@@ -25,11 +25,12 @@ var elemIds = {
   form: 'search-form',
   resultsNewWindow: 'open-results-new-window',
   advancedOptions: 'advanced-options',
-  clearOptions: 'clear-options',
+  resetSearchForm: 'reset-search-form',
 };
 
-function clearOptions(event) {
+function resetSearchForm(event) {
   for (const field of [
+    elemIds.url,
     elemIds.match,
     elemIds.dateTime.from,
     elemIds.dateTime.fromTime,
@@ -206,7 +207,7 @@ $(document).ready(function() {
     elemIds.dateTime.to,
     document.getElementById(elemIds.dateTime.toBad)
   );
-  document.getElementById(elemIds.clearOptions).onclick = clearOptions;
+  document.getElementById(elemIds.resetSearchForm).onclick = resetSearchForm;
   document.getElementById(elemIds.filtering.add).onclick = addFilter;
   document.getElementById(elemIds.filtering.clear).onclick = clearFilters;
   var searchURLInput = document.getElementById(elemIds.url);

--- a/pywb/templates/search.html
+++ b/pywb/templates/search.html
@@ -66,8 +66,8 @@
                         aria-expanded="false" aria-controls="advancedOptions" aria-label="{{ _('Search Options') }}">
                     {{ _('Search Options') }}
                 </button>
-                <button id="clear-options" class="btn btn-outline-danger float-right mr-3" type="button" role="button" aria-label="{{ _('Reset Options') }}">
-                    {{ _('Reset Options') }}
+                <button id="reset-search-form" class="btn btn-outline-danger float-right mr-3" type="button" role="button" aria-label="{{ _('Reset Options') }}">
+                    {{ _('Reset') }}
                 </button>
             </div>
         </div>

--- a/pywb/templates/search.html
+++ b/pywb/templates/search.html
@@ -58,15 +58,15 @@
                 </div>
             </div>
             <div class="col-7">
-                <button type="submit" id="search-button" class="btn btn-outline-primary float-right" role="button" aria-label="{{ _('Search') }}">
+                <button type="submit" id="search-button" class="btn btn-primary float-right" role="button" aria-label="{{ _('Search') }}">
                     {% trans %}Search{% endtrans %}
                 </button>
-                <button class="btn btn-outline-info float-right mr-3" type="button" role="button"
+                <button class="btn btn-outline-secondary float-right mr-3" type="button" role="button"
                         data-toggle="collapse" data-target="#advancedOptions" id="advanced-options"
                         aria-expanded="false" aria-controls="advancedOptions" aria-label="{{ _('Search Options') }}">
                     {{ _('Search Options') }}
                 </button>
-                <button id="clear-options" class="btn btn-outline-warning float-right mr-3" type="button" role="button" aria-label="{{ _('Reset Options') }}">
+                <button id="clear-options" class="btn btn-outline-danger float-right mr-3" type="button" role="button" aria-label="{{ _('Reset Options') }}">
                     {{ _('Reset Options') }}
                 </button>
             </div>
@@ -153,7 +153,7 @@
                         <ul id="filter-list" class="filter-list">
                             <li id="filtering-nothing">{% trans %}No Filter{% endtrans %}</li>
                         </ul>
-                        <button id="clear-filters" class="btn btn-outline-warning float-right mr-2" type="button">
+                        <button id="clear-filters" class="btn btn-outline-danger float-right mr-2" type="button">
                             {% trans %}Clear Filters{% endtrans %}
                         </button>
                     </div>


### PR DESCRIPTION
## Description

This PR modifies the search template's button colors for readability/UX purposes, and replaces the "Clear Options" button with a "Reset" button that clears both the search options and the URL search box.

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/6758804/214164565-e70399d0-eb95-463b-8bd3-b281789d8ff1.png)

After:

<img width="1171" alt="Screen Shot 2023-01-23 at 5 30 28 PM" src="https://user-images.githubusercontent.com/6758804/214164629-1c461be8-864e-41e6-8fd8-a02e40ff8806.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [X] All new and existing tests passed.
