### PR TITLE
Sort index when adding wacz archives

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -75,9 +75,14 @@ class TestManager:
                                 {'example.warc.gz': 'rewritten.warc.gz'})
         with open(os.path.join(manager.indexes_dir, manager.DEF_INDEX_FILE), 'r') as f:
             index_content = f.read()
+            index_content = index_content.strip()
 
         assert 'example.warc.gz' not in index_content
         assert 'rewritten.warc.gz' in index_content
+
+        # check that collection index is sorted
+        index_lines = index_content.split('\n')
+        assert sorted(index_lines) == index_lines
 
     def test_merge_wacz_index_gzip(self, tmp_path):
         manager = self.get_test_collections_manager(tmp_path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

Ensure that collection index is sorted when adding wacz archives to the collection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

CDXJ indices must be sorted for the binary search algorithm to work. When adding wacz archives and merging there indices with the collection index, the wacz index was just appended to the end of the collection index and the collection index wasn't sorted anymore.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
