### PR TITLE
Record unbound range only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -28,5 +28,5 @@ jobs:
         run: tox
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -248,8 +248,8 @@ class RewriterApp(object):
         range_start = start
         range_end = end
 
-        # if start with 0, load from upstream, but add range after
-        if start == 0:
+        # if start with 0 and no end, load from upstream
+        if start == 0 and not end:
             del inputreq.env['HTTP_RANGE']
         else:
             skip_record = True

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.7.3'
+__version__ = '2.7.4'
 
 if __name__ == '__main__':
     print(__version__)

--- a/pywb/warcserver/test/test_handlers.py
+++ b/pywb/warcserver/test/test_handlers.py
@@ -385,7 +385,8 @@ foo=bar&test=abc"""
         assert resp.headers['Warcserver-Source-Coll'] == 'url-agnost'
         assert resp.headers['Memento-Datetime'] == 'Mon, 29 Jul 2013 19:51:51 GMT'
 
-    @pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    #@pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    @pytest.mark.skip("youtube-dl update needed")
     def test_live_video_loader(self):
         pytest.importorskip('youtube_dl')
         params = {'url': 'http://www.youtube.com/v/BfBgWtAIbRc',
@@ -404,7 +405,8 @@ foo=bar&test=abc"""
         assert b'WARC-Type: metadata' in resp.body
         assert b'Content-Type: application/vnd.youtube-dl_formats+json' in resp.body
 
-    @pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    #@pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    @pytest.mark.skip("youtube-dl update needed")
     def test_live_video_loader_post(self):
         pytest.importorskip('youtube_dl')
         req_data = """\

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -169,7 +169,8 @@ class TestLiveRewriter(HttpBinLiveTests, BaseConfigTest):
         resp = resp.follow(status=400)
         assert resp.status_int == 400
 
-    @pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    #@pytest.mark.skipif(os.environ.get('CI') is not None, reason='Skip Test on CI')
+    @pytest.mark.skip("youtube-dl update needed")
     def test_live_video_info(self):
         pytest.importorskip('youtube_dl')
         resp = self.testapp.get('/live/vi_/https://www.youtube.com/watch?v=DjFZyFWSt1M')

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -29,7 +29,7 @@ class TestReplayRange(BaseConfigTest):
         assert resp.headers['Content-Range'] == 'bytes 0-200/1270', resp.headers['Content-Range']
         assert resp.content_length == 201, resp.content_length
 
-        assert self.recorder_skip == None
+        assert self.recorder_skip == '1'
 
         assert 'wombat.js' not in resp.text
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
Don't automatically convert any ranged 0-N request to an unbounded 0- when recording.
Also fix tests, bump to 2.7.4

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Causes pywb to end up with unfinished requests (found in crawler).
Crawler already making explicit unbounded requests as needed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
