### PR TITLE
Sets "Pywb Error" string as translatable in error template

### DIFF
--- a/pywb/templates/error.html
+++ b/pywb/templates/error.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="container text-danger error">
     <div class="row justify-content-center">
-        <h2 class="display-2">Pywb Error</h2>
+        <h2 class="display-2">{{ _('Pywb Error') }}</h2>
     </div>
     <div class="row">
         <div class="col-12 text-center">


### PR DESCRIPTION
## Description
Sets the "Pywb Error" string in the `<h2>` heading as translatable in the error.html template.

## Motivation and Context
- The string "Pywb Error" isn't translatable [in this line](https://github.com/webrecorder/pywb/blob/main/pywb/templates/error.html#L6).
- Fixes #867 

## Screenshots (if appropriate):
![image](https://github.com/webrecorder/pywb/assets/5452565/af89dbe6-119d-45a0-af22-12586e5d6938)
The "Pywb Error" isn't translated, but this pull request fixes that.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.

I have no idea how to run the tests, but hopefully just making a string translatable shouldn't break anything.