### PR TITLE
Fixes switch_locale not adding locale if missing from URL

### DIFF
--- a/pywb/rewrite/templateview.py
+++ b/pywb/rewrite/templateview.py
@@ -178,7 +178,7 @@ class JinjaEnv(object):
 
             request_uri = environ.get('REQUEST_URI', environ.get('PATH_INFO'))
 
-            if curr_loc:
+            if curr_loc and request_uri.startswith('/' + curr_loc + '/'):
                 return request_uri.replace(curr_loc, locale, 1)
 
             app_prefix = environ.get('pywb.app_prefix', '')


### PR DESCRIPTION
If the language code was missing in the URI, switch_locale(locale) didn't add it (it worked fine if it was present). That means that it produced the same URL for all locales, each missing the language code in the URL.

## Description
I added an additional check that checks if the language is set in the URI, and it is changed only in that case. Otherwise if it was missing, it was producing a URL that doesn't contain it - but now it does add the launguage code to the URL if it was missing.

## Motivation and Context
Fixes #870

## Screenshots (if appropriate):
<img width="471" alt="image" src="https://github.com/webrecorder/pywb/assets/5452565/a52e8fc9-a3aa-4bcc-afa7-a7208208cb02">

Notice the current URL for a collection named "test" (not containing any language code in the URL). I hovered the mouse over the link to change the locale to "hr" (top right), and the URL that is in that link is shown on bottom left - it doesn't contain "hr". Same happens when I hover over "en".

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.

I don't know how to run the tests.