### PR TITLE
Fixes environ paths when default_locale set

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -667,10 +667,14 @@ class FrontEndApp(object):
             # store original script_name (original prefix) before modifications are made
             environ['ORIG_SCRIPT_NAME'] = environ.get('SCRIPT_NAME')
 
-            lang = args.pop('lang', self.default_locale)
+            lang = args.pop('lang', '')
             if lang:
                 pop_path_info(environ)
+
+            if lang:
                 environ['pywb_lang'] = lang
+            elif self.default_locale:
+                environ['pywb_lang'] = self.default_locale
 
             response = endpoint(environ, **args)
 


### PR DESCRIPTION
## Description
If the default_locale was set in config.yaml and the URL path didn't contain a language code, it was behaving as if there was a language code in the URL. In that case, it was moving part of the PATH_INFO to SCRIPT_NAME, but as there wasn't any language code in the URL path, it moved something else. This fixes that.

## Motivation and Context
I noticed this bug when the search results (by domain) didn't show any results, in the condition described above.
This fixes #872

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I marked it as bug fix, instead of a breaking change, but I'm not 100% sure.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.

I don't know how to run tests.