### PR TITLE
Mention Apache's AddDefaultCharset directive in docs

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -307,6 +307,13 @@ Then, in your config, simply include:
 
 The configuration assumes uwsgi is started with ``uwsgi uwsgi.ini``
 
+Note, the default httpd.conf may include the directive ``AddDefaultCharset UTF-8``.
+This may cause the � replacement character to appear for some characters when replaying archived HTML content that specifies an alternative charset in the META tags.
+To allow the charset specified by the archived content to prevail, comment out the directive:
+
+.. code:: apache
+
+    # AddDefaultCharset UTF-8
 
 .. _config-acl-header:
 


### PR DESCRIPTION
Updates the usage documentation to mention Apache's `AddDefaultCharset` directive that is included in the default httpd.conf file of some versions of Apache.

## Description
This adds a note to the documentation regarding deploying with Apache about looking for the `AddDefaultCharset` in the httpd.conf and commenting it out if present to prevent issues related to character encoding with replaying archived HTML that uses a different charset.

## Motivation and Context
I am suggesting this addition to the documentation because it is an issue I encountered with our production instance of pywb that runs with Apache and uWSGI.

## Screenshots (if appropriate):
This is the issue the documentation addition addresses:
![pywb_apache_charset_issue](https://github.com/webrecorder/pywb/assets/6740390/437b9a82-7bea-4250-a80e-f18ed39c5e11)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
