### PR TITLE
Allow ACLJs to use *, SURT wildcard to match all URLs

### DIFF
--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -105,6 +105,10 @@ Given these rules, a user would:
 * but would receive an 'access blocked' error message when viewing ``http://httpbin.org/`` (block)
 * would receive a 404 not found error when viewing ``http://httpbin.org/anything`` (exclude)
 
+To match any possible URL in an .aclj file, set ``*,`` as the leading SURT, for example::
+
+  *, - {"access": "allow"}
+
 
 Access Types: allow, block, exclude, allow_ignore_embargo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,6 +152,10 @@ Combined with the embargo settings, this can also be used to override the embarg
 To make this work, pywb must be running behind an Apache or Nginx system that is configured to set ``X-Pywb-ACL-User: staff`` based on certain settings.
 
 For example, this header may be set based on IP range, or based on password authentication.
+
+To allow a user access to all URLs, overriding more specific rules and the ``default_access`` configuration setting, use the ``*,`` SURT::
+
+  *, - {"access": "allow", "user": "staff"}
 
 Further examples of how to set this header will be provided in the deployments section.
 

--- a/docs/manual/access-control.rst
+++ b/docs/manual/access-control.rst
@@ -109,6 +109,8 @@ To match any possible URL in an .aclj file, set ``*,`` as the leading SURT, for 
 
   *, - {"access": "allow"}
 
+Lines starting with ``*,`` should generally be at the end of the file, respecting the reverse alphabetical order.
+
 
 Access Types: allow, block, exclude, allow_ignore_embargo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pywb/warcserver/access_checker.py
+++ b/pywb/warcserver/access_checker.py
@@ -260,6 +260,10 @@ class AccessChecker(object):
             if key.startswith(acl_key):
                 acl_obj = CDXObject(acl)
 
+            # Check for "*," in ACL, which matches any URL
+            if acl_key == b"*,":
+                acl_obj = CDXObject(acl)
+
             if acl_obj:
                 user = acl_obj.get('user')
                 if user == acl_user:

--- a/sample_archive/access/allow_all.aclj
+++ b/sample_archive/access/allow_all.aclj
@@ -1,0 +1,1 @@
+*, - {"access": "allow", "user": "staff"}

--- a/tests/config_test_access.yaml
+++ b/tests/config_test_access.yaml
@@ -62,6 +62,13 @@ collections:
         acl_paths:
             - ./sample_archive/access/pywb.aclj
 
+    pywb-wildcard-surt:
+        index_paths: ./sample_archive/cdx/
+        archive_paths: ./sample_archive/warcs/
+        default_access: block
+        acl_paths:
+            - ./sample_archive/access/allow_all.aclj
+
 
 
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -96,5 +96,9 @@ class TestACLApp(BaseConfigTest):
 
         assert '"http://httpbin.org/anything/resource.json"' in resp.text
 
+    def test_allow_all_acl_user_specific(self):
+        resp = self.testapp.get('/pywb-wildcard-surt/mp_/http://example.com/', status=451)
 
+        assert 'Access Blocked' in resp.text
 
+        resp = self.testapp.get('/pywb-wildcard-surt/mp_/http://example.com/', headers={"X-Pywb-Acl-User": "staff"}, status=200)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

Fixes #881

## Description
<!--- Describe your changes in detail -->

This PR adds the option to use `*,` as a SURT in ACLJ files to match any URL. This builds off of the existing ability to do this per-TLD, e.g. `com,`.

The PR also adds a passing test for the use case described in the issue (overriding `default_access: block` to all URLs for a specific user), and documents the new option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

This allows administrators to give access to all resources to specific (e.g. staff) users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed
