### PR TITLE
Handle WARC filename conflicts with wb-manager add

### DIFF
--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -7,6 +7,7 @@ import yaml
 import re
 import gzip
 import six
+import pathlib
 
 from distutils.util import strtobool
 from pkg_resources import resource_string, get_distribution
@@ -149,8 +150,11 @@ directory structure expected by pywb
 
     def _rename_warc(self, warc_basename):
         dupe_idx = 1
+        ext = ''.join(pathlib.Path(warc_basename).suffixes)
+        pre_ext_name = warc_basename.split(ext)[0]
+
         while True:
-            new_basename = f'{warc_basename}-{dupe_idx}'
+            new_basename = f'{pre_ext_name}-{dupe_idx}{ext}'
             if not os.path.exists(os.path.join(self.archive_dir, new_basename)):
                 break
             dupe_idx += 1

--- a/pywb/manager/manager.py
+++ b/pywb/manager/manager.py
@@ -147,7 +147,7 @@ directory structure expected by pywb
         if invalid_archives:
             logging.warning(f'Invalid archives weren\'t added: {", ".join(invalid_archives)}')
 
-    def _rename_warc(self, source_dir, warc_basename):
+    def _rename_warc(self, warc_basename):
         dupe_idx = 1
         while True:
             new_basename = f'{warc_basename}-{dupe_idx}'
@@ -163,7 +163,7 @@ directory structure expected by pywb
 
         # don't overwrite existing warcs with duplicate names
         if os.path.exists(os.path.join(self.archive_dir, warc_basename)):
-            warc_basename = self._rename_warc(source_dir, warc_basename)
+            warc_basename = self._rename_warc(warc_basename)
             logging.info(f'Warc {os.path.basename(warc)} already exists - renamed to {warc_basename}.')
 
         warc_dest = os.path.join(self.archive_dir, warc_basename)
@@ -209,8 +209,9 @@ directory structure expected by pywb
             warc_destination_path = os.path.join(self.archive_dir, warc_filename)
 
             if os.path.exists(warc_destination_path):
-                logging.warning(f'Warc {warc_filename} wasn\'t added because of duplicate name.')
-                continue
+                warc_filename = self._rename_warc(warc_filename)
+                logging.info(f'Warc {warc_destination_path} already exists - renamed to {warc_filename}.')
+                warc_destination_path = os.path.join(self.archive_dir, warc_filename)
 
             warc_filename_mapping[os.path.basename(extracted_warc_file)] = warc_filename
             shutil.copy2(os.path.join(temp_dir, extracted_warc_file), warc_destination_path)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -20,6 +20,20 @@ class TestManager:
         with open(os.path.join(manager.indexes_dir, manager.DEF_INDEX_FILE), 'r') as f:
             assert '"filename": "valid_example_1-0.warc"' in f.read()
 
+    def test_add_valid_wacz_unpacked_dupe_name(self, tmp_path):
+        """Test if warc that already exists is renamed with -index suffix"""
+        manager = self.get_test_collections_manager(tmp_path)
+        manager._add_wacz_unpacked(VALID_WACZ_PATH)
+        # Add it again to see if there are name conflicts
+        manager._add_wacz_unpacked(VALID_WACZ_PATH)
+        assert 'valid_example_1-0.warc' in os.listdir(manager.archive_dir)
+        assert 'valid_example_1-0-1.warc' in os.listdir(manager.archive_dir)
+        assert manager.DEF_INDEX_FILE in os.listdir(manager.indexes_dir)
+        with open(os.path.join(manager.indexes_dir, manager.DEF_INDEX_FILE), 'r') as f:
+            data = f.read()
+            assert '"filename": "valid_example_1-0.warc"' in data
+            assert '"filename": "valid_example_1-0-1.warc"' in data
+
     def test_add_invalid_wacz_unpacked(self, tmp_path, caplog):
         """Test if adding an invalid wacz file to a collection fails"""
         manager = self.get_test_collections_manager(tmp_path)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -68,8 +68,7 @@ class TestManager:
     def test_add_valid_archives_dupe_name(self, tmp_path):
         manager = self.get_test_collections_manager(tmp_path)
         warc_filename = 'sample_archive/warcs/example.warc.gz'
-        manager.add_archives(warc_filename)
-        manager.add_archives(warc_filename)
+        manager.add_archives([warc_filename, warc_filename])
 
         with open(os.path.join(manager.indexes_dir, manager.DEF_INDEX_FILE), 'r') as f:
             index_text = f.read()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -65,6 +65,21 @@ class TestManager:
             assert archive in os.listdir(manager.archive_dir)
             assert archive in index_text
 
+    def test_add_valid_archives_dupe_name(self, tmp_path):
+        manager = self.get_test_collections_manager(tmp_path)
+        warc_filename = 'sample_archive/warcs/example.warc.gz'
+        manager.add_archives(warc_filename)
+        manager.add_archives(warc_filename)
+
+        with open(os.path.join(manager.indexes_dir, manager.DEF_INDEX_FILE), 'r') as f:
+            index_text = f.read()
+
+        expected_archives = ('example.warc.gz', 'example-1.warc.gz')
+
+        for archive in expected_archives:
+            assert archive in os.listdir(manager.archive_dir)
+            assert archive in index_text
+
     def test_add_valid_archives_dont_unpack_wacz(self, tmp_path):
         manager = self.get_test_collections_manager(tmp_path)
         archives = ['sample_archive/warcs/example.arc', 'sample_archive/warcs/example.arc.gz',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

Instead of not copying a WARC to the archive directory in case of a filename conflict, this PR instead modifies it to add the WARC with `{original_name}-{dupe index}{extension}` - i.e. `example.warc.gz` would be renamed to `example-1.warc.gz`, then `example-2.warc.gz`, and so on, until a filename that doesn't exist in the archive directory is found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Should make for a more user-friendly experience of adding archives via `wb-manager add`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
