### PR TITLE
Pin redis for fakeredis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six
 warcio>=1.7.1
 requests
-redis
+redis==2.10.6
 jinja2>=3.1.2
 surt>=0.3.1
 brotlipy


### PR DESCRIPTION
## Description

It looks like `poetry install` will install the latest version of redis (v5.0.4) instead of what pip installs (v2.10.6). Unfortunately this means that the old version of fakeredis that is pinned in the requirements.txt will not work properly.

Fixes #903

## Motivation and Context

To be able to run pywb using a poetry virtual environment.

## Types of changes

- [ ] Replay fix (fixes a replay specific issue)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
