### PR TITLE
Preventing the Python 3.12's "Deprecated since version 3.12: Use datetime.now() with UTC instead."

### DIFF
--- a/pywb/recorder/multifilewarcwriter.py
+++ b/pywb/recorder/multifilewarcwriter.py
@@ -245,7 +245,7 @@ class MultiFileWARCWriter(BaseWARCWriter):
         if not self.max_idle_time:
             return
 
-        now = datetime.datetime.now()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         for dir_key, out, filename in self.iter_open_files():
             try:
@@ -254,7 +254,7 @@ class MultiFileWARCWriter(BaseWARCWriter):
                 self.close_key(dir_key)
                 return
 
-            mtime = datetime.datetime.fromtimestamp(mtime)
+            mtime = datetime.datetime.fromtimestamp(mtime,tz=datetime.timezone.utc)
 
             if (now - mtime) > self.max_idle_time:
                 print('Closing idle ' + filename)

--- a/pywb/rewrite/header_rewriter.py
+++ b/pywb/rewrite/header_rewriter.py
@@ -1,6 +1,6 @@
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.timeutils import datetime_to_http_date
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from six.moves.urllib.parse import urlsplit
 
 
@@ -166,7 +166,7 @@ class DefaultHeaderRewriter(object):
         if age <= 0:
             new_headers.append(('Cache-Control', 'no-cache; no-store'))
         else:
-            dt = datetime.utcnow()
+            dt = datetime.now(timezone.utc)
             dt = dt + timedelta(seconds=age)
             new_headers.append(('Cache-Control', 'max-age=' + str(age)))
             new_headers.append(('Expires', datetime_to_http_date(dt)))

--- a/pywb/rewrite/test/test_header_rewriter.py
+++ b/pywb/rewrite/test/test_header_rewriter.py
@@ -7,7 +7,7 @@ from pywb.rewrite.default_rewriter import DefaultRewriter
 from pywb.rewrite.header_rewriter import DefaultHeaderRewriter
 from pywb.rewrite.url_rewriter import UrlRewriter
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from io import BytesIO
 
@@ -163,7 +163,7 @@ def _test_cookie_headers():
 def _make_cache_headers():
     cache_headers = [('Content-Length', '123'),
                      ('Cache-Control', 'max-age=10'),
-                     ('Expires', datetime_to_http_date(datetime.now())),
+                     ('Expires', datetime_to_http_date(datetime.now(timezone.utc))),
                      ('ETag', '123456')]
     return cache_headers
 

--- a/pywb/warcserver/access_checker.py
+++ b/pywb/warcserver/access_checker.py
@@ -7,7 +7,7 @@ from pywb.utils.binsearch import search
 from pywb.utils.merge import merge
 
 from warcio.timeutils import timestamp_to_datetime
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 import os
 
@@ -164,13 +164,13 @@ class AccessChecker(object):
         # embargo if newser than
         newer = self.embargo.get('newer')
         if newer:
-            actual = datetime.utcnow() - newer
+            actual = datetime.now(timezone.utc) - newer
             return access if actual < dt else None
 
         # embargo if older than
         older = self.embargo.get('older')
         if older:
-            actual = datetime.utcnow() - older
+            actual = datetime.now(timezone.utc) - older
             return access if actual > dt else None
 
     def create_access_aggregator(self, source_files):

--- a/pywb/warcserver/index/zipnum.py
+++ b/pywb/warcserver/index/zipnum.py
@@ -136,7 +136,7 @@ class ZipNumIndexSource(BaseIndexSource):
         self.summary = summary
 
         # reload interval
-        self.loc_update_time = datetime.datetime.now()
+        self.loc_update_time = datetime.datetime.now(datetime.timezone.utc)
         self.reload_interval = datetime.timedelta(minutes=reload_ival)
 
         self.blk_loader = BlockLoader(cookie_maker=cookie_maker)

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -430,7 +430,7 @@ class LiveWebLoader(BaseLoader):
         warc_headers['WARC-Date'] = datetime_to_iso_date(dt)
 
         if not cdx.get('is_live'):
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc)
             warc_headers['WARC-Source-URI'] = cdx.get('load_url')
             warc_headers['WARC-Creation-Date'] = datetime_to_iso_date(now)
 


### PR DESCRIPTION
## Description

See https://github.com/webrecorder/pywb/issues/913

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
