### PR TITLE
A fix for GitHub issue #865

### DIFF
--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -285,8 +285,8 @@ class LiveWebLoader(BaseLoader):
             self.socks_proxy = None
 
     def load_resource(self, cdx, params):
-        #if cdx.get('filename') and cdx.get('offset') is not None:
-        #    return None
+        if cdx.get('filename') and cdx.get('offset') is not None:
+            return None
 
         load_url = cdx.get('load_url')
         if not load_url:


### PR DESCRIPTION
## Description
This PR fixes the issue #865. Specifically, it appears that the bug was introduced (perhaps by mistake) by commenting out lines 288-289 from `responseloader.py`. It appears that uncommenting these lines, i.e., returning from the method if there is already a WARC filename and offset for the record, then the self-redirects work correctly. These lines were commented between versions 2.6.9 and 2.7.0b, which corresponds to the issue description. After this bug fix, self-redirects work correctly once again (on a local test system).

## Motivation and Context
Solves #865.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
