### PR TITLE
Allow to configure uWSGI mount via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /webarchive
 ENV INIT_COLLECTION ''
 
 ENV VOLUME_DIR /webarchive
+ENV UWSGI_MOUNT '/=/pywb/pywb/apps/wayback.py'
 
 #USER archivist
 COPY docker-entrypoint.sh ./
@@ -31,4 +32,3 @@ EXPOSE 8080
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["uwsgi", "/uwsgi/uwsgi.ini"]
-

--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -373,6 +373,8 @@ For example, to deploy pywb under the ``/wayback`` subdirectory, the ``uwsgi.ini
     mount = /wayback=./pywb/apps/wayback.py
     manage-script-name = true
 
+Alternatively this can also be achieved using the `UWSGI_MOUNT` environment variable, e.g. with the value `/wayback=/pywb/pywb/apps/wayback.py`.
+This is specifically handy on the docker image.
 
 .. _example-deploy:
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -22,4 +22,13 @@ env = GEVENT_MONKEY_PATCH=1
 
 # specify config file here
 env = PYWB_CONFIG_FILE=config.yaml
+
+if-not-env = UWSGI_MOUNT
 wsgi = pywb.apps.wayback
+endif =
+
+# Set the path to which pywb should be mounted
+if-env = UWSGI_MOUNT
+mount = %(_)
+manage-script-name = true
+endif =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
By introducing the UWSGI_MOUNT environment variable in the default `uwsgi.ini` it is not possible to configure the uWSGI mount with an environment variable on the OCI/docker image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously it required to mount a `uwsgi.ini` file for this configuration which is not handy in all setups.
Just setting the argument `--mount` on the command did not work as it collides with the `wsgi` setting in the default `uwsgi.ini`.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
