### PR TITLE
simplify: use existing prefix as archivePrefix, fixes #937

### DIFF
--- a/pywb/static/loadWabac.js
+++ b/pywb/static/loadWabac.js
@@ -7,7 +7,6 @@ class WabacReplay
     this.staticPrefix = staticPrefix;
     this.collName = coll;
     this.isRoot = coll === "$root";
-    this.archivePrefix = this.isRoot ? "/" : `/${this.collName}/`;
     this.swScope = swScopePrefix;
     this.adblockUrl = undefined;
 
@@ -51,7 +50,7 @@ class WabacReplay
         baseUrl: this.prefix,
         baseUrlAppendReplay: true,
         noPostToGet: false,
-        archivePrefix: this.archivePrefix,
+        archivePrefix: this.prefix,
         archiveMod: "ir_",
         adblockUrl: this.adblockUrl,
         noPostToGet: true,
@@ -86,6 +85,6 @@ class WabacReplay
   // called by the Vue banner when the timeline is clicked
   load_url(url, ts) {
     const iframe = document.querySelector('#replay_iframe');
-    iframe.src = `${this.swScope}${this.archivePrefix}${ts}mp_/${url}`;
+    iframe.src = `${this.prefix}${ts}mp_/${url}`;
   }
 }

--- a/pywb/version.py
+++ b/pywb/version.py
@@ -1,4 +1,4 @@
-__version__ = '2.9.0-beta.0'
+__version__ = '2.9.0b1'
 
 if __name__ == '__main__':
     print(__version__)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from pywb import __version__
 root_dir = pathlib.Path(__file__).parent
 
 
-WABAC_SW_URL = "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.22.12/dist/sw.js"
+WABAC_SW_URL = "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.22.15/dist/sw.js"
 
 def download_wabac_sw():
     print(f"Downloading {WABAC_SW_URL}")


### PR DESCRIPTION
## Description
Fixes #937 

Use existing prefix for wabac.js `archivePrefix` instead of recomputing, ensures passthrough handles mount prefix.

Update wabac.js to 2.22.15
bump to 2.9.0b1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
