### PR TITLE
documented python3-dev dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,10 @@ Please see the `full documentation <https://pywb.readthedocs.org>`_ for more det
 Installation for Deployment
 ---------------------------
 
+On Linux-based systems, first verify that ``python3-dev`` is installed. If it is not, install it with your package manager. E.g. on a Debian-based system, use:
+
+``sudo apt install python3-dev``
+
 To install pywb for usage, you can use:
 
 ``pip install pywb``


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

Added line that explains python3-dev dependency on Linux-based systems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

Without python3-dev the C extensions won't build, but this is currently not mentioned in the docs. See also <https://github.com/webrecorder/pywb/issues/954>.
