### PR TITLE
Upgrade greenlet and gevent for Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,10 @@ brotlipy
 pyyaml
 werkzeug==2.2.3
 webencodings
-gevent==22.10.2
-greenlet>=2.0.2,<3.0
+gevent==22.10.2; python_version<"3.8"
+gevent==23.9.0; python_version>="3.8"
+greenlet>=2.0.2,<3.0; python_version<"3.12"
+greenlet==3.2.4; python_version>="3.12.0rc0"
 webassets==2.0
 portalocker
 wsgiprox>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
             "translate_toolkit"
         ],
     },
-    python_requires='>=3.7,<3.12',
+    python_requires='>=3.7,<3.13',
     tests_require=load_requirements("test_requirements.txt"),
     cmdclass={'test': PyTest},
     test_suite='',
@@ -151,6 +151,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: WSGI',

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ testpaths =
     tests
 
 [tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310, py311, py312
 
 [gh-actions]
 python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 setenv = PYWB_NO_VERIFY_SSL = 1


### PR DESCRIPTION
 ## Description
This adjusts the requirements.txt file for versions of greenlet and gevent that look like they work with Python 3.12 by specifying different versions based on which Python version is installing them. Selected versions are based on the Changes lists for those packages and takes into account the [httbin dependencies](https://github.com/psf/httpbin/blob/e32f9933af1386f580d737578e1051d656e8d4c7/pyproject.toml#L37) (httpbin now supports Python 3.12).

## Motivation and Context
This is to make it minimally viable to run pywb with Python 3.12. It would fix #954. 

I ran tests locally, but no matter with this requirements change or not, on various versions of python, 3 tests related to live video stuff (youtube) fail. I see these tests are marked to be skipped though when run via CI.

## Screenshots (if appropriate):

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue--not really a bug, but there is an issue open to address this)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed (via CI they pass, locally the same live video/youtube related tests fail for me that failed before this change).
