### PR TITLE
Better fix for #865 / differentiate between remote cdx + local WARCs and remote cdx + liveweb loader

### DIFF
--- a/pywb/warcserver/handlers.py
+++ b/pywb/warcserver/handlers.py
@@ -175,9 +175,10 @@ class ResourceHandler(IndexHandler):
 #=============================================================================
 class DefaultResourceHandler(ResourceHandler):
     def __init__(self, index_source, warc_paths='', forward_proxy_prefix='',
+                 use_local_file_load=False,
                  **kwargs):
         loaders = [WARCPathLoader(warc_paths, index_source),
-                   LiveWebLoader(forward_proxy_prefix),
+                   LiveWebLoader(forward_proxy_prefix, use_local_file_load=use_local_file_load),
                    VideoLoader()
                   ]
         super(DefaultResourceHandler, self).__init__(index_source, loaders, **kwargs)

--- a/pywb/warcserver/resource/responseloader.py
+++ b/pywb/warcserver/resource/responseloader.py
@@ -274,8 +274,11 @@ class LiveWebLoader(BaseLoader):
                    'application/vnd.apple.mpegurl',
                    'application/dash+xml')
 
-    def __init__(self, forward_proxy_prefix=None, adapter=None):
+    def __init__(self, forward_proxy_prefix=None, adapter=None, use_local_file_load=False):
         self.forward_proxy_prefix = forward_proxy_prefix
+
+        # indicates if WARCs can be loaded locally, even if we get to this fallback
+        self.use_local_file_load = use_local_file_load
 
         socks_host = os.environ.get('SOCKS_HOST')
         socks_port = os.environ.get('SOCKS_PORT', 9050)
@@ -285,8 +288,11 @@ class LiveWebLoader(BaseLoader):
             self.socks_proxy = None
 
     def load_resource(self, cdx, params):
-        #if cdx.get('filename') and cdx.get('offset') is not None:
-        #    return None
+        if cdx.get('filename') and cdx.get('offset') is not None:
+            # if loading locally, skip here so can retry
+            # in case of revisit
+            if self.use_local_file_load:
+                return None
 
         load_url = cdx.get('load_url')
         if not load_url:

--- a/pywb/warcserver/warcserver.py
+++ b/pywb/warcserver/warcserver.py
@@ -244,6 +244,9 @@ class WarcServer(BaseWarcServer):
         # ARCHIVE CONFIG
         if not archive_paths:
             archive_paths = self.config.get('archive_paths')
+            use_local_file_load = False
+        else:
+            use_local_file_load = True
 
         # ACCESS CONFIG
         access_checker = None
@@ -252,7 +255,8 @@ class WarcServer(BaseWarcServer):
 
         return DefaultResourceHandler(agg, archive_paths,
                                       rules_file=self.rules_file,
-                                      access_checker=access_checker)
+                                      access_checker=access_checker,
+                                      use_local_file_load=use_local_file_load)
 
     def init_sequence(self, coll_name, seq_config):
         if not isinstance(seq_config, list):


### PR DESCRIPTION
The fix is to be more concretely differentiate between these two configurations:

```
# remote cdx + remote proxy loading via LiveWebLoader
remote: cdx+https://remote-archive.example.com/web/cdx

# remote cdx + but *local* WARC loading:
local_coll:
    index_paths: cdx+http://outbackcdx:8080/coll
    archive_paths: /path/to/mywarcs/
```

The former is for proxying via remote CDX while the latter is the [recommend config for OutbackCDX](https://pywb.readthedocs.io/en/latest/manual/outbackcdx.html#configure-pywb-with-outbackcdx) 

These supersedes the fix proposed in #917 by adding a conditional to check which configuration is used
(remote cdx + local loading or remote cdx + remote liveweb loading) by checking if `archive_paths` was provided,
as is needed for usage with OutbackCDX

The skipping of the livewebloader
is needed to be able to retry the lookup path again for revisit records, while of course remote proxying
will not need to do that.

Fixes #865 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
