### PR TITLE
Unregister the service worker when client_side_replay is off

### DIFF
--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -53,12 +53,14 @@ html, body
 <script>
   window.cframe = null;
 
-{% if client_side_replay %}
   if (navigator.serviceWorker) {
+{% if client_side_replay %}
     window.cframe = new WabacReplay("{{ wb_prefix }}", "{{ url }}", "{{ timestamp }}", "{{ static_prefix }}", "{{ coll }}", "{{ sw_prefix }}");
     window.cframe.init();
-  }
+{% else %}
+    navigator.serviceWorker.getRegistration("{{ sw_prefix }}").then(reg => { if (reg) reg.unregister() });
 {% endif %}
+  }
   if (!window.cframe) {
     window.cframe = new ContentFrame({"url": "{{ url }}" + window.location.hash,
                                  "prefix": "{{ wb_prefix }}",


### PR DESCRIPTION
## Description

This change makes pywb unregister the wabac.js serviceworker when `client_side_replay: false` is set.

## Motivation and Context

If you have client_side_replay on and later turn it off, prior visitors will still have it registered in their browser unless they manually remove it through devtools or by clearing site data. While we don't expect to be regularly flipping it on and off in production, it's important to be able to roll back to the previous configuration if an issue is discovered.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
