### PR TITLE
Update test_html_rewriter to match Python HtmlParser's new behavior

### DIFF
--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -413,8 +413,10 @@ r"""
 <!--[if !IE]><html><![endif]--><a href="/web/20131226101010/http://example.com/"><!--[if IE]><![endif]--><a href="/web/20131226101010/http://example.com/"></html>
 
 # IE conditional with invalid ']-->' ending, rewritten as ']>'
+# Note: HtmlParser was changed in Python 3.9.24, 3.10.19, 3.11.14, 3.12.12, 3.13.6, 3.14.0.
+# The output of this test will differ on older Python versions.
 >>> parse('<!--[if !IE]> --><html><![endif]--><a href="http://example.com/"><!--[if IE]><![endif]--><a href="http://example.com/"></html>')
-<!--[if !IE]> --><html><![endif]><a href="/web/20131226101010/http://example.com/"><!--[if IE]><![endif]--><a href="/web/20131226101010/http://example.com/"></html>
+<!--[if !IE]> --><html><!--[endif]----><a href="/web/20131226101010/http://example.com/"><!--[if IE]><![endif]--><a href="/web/20131226101010/http://example.com/"></html>
 
 # Test tag with a target
 >>> parse('<HTML><A Href=\"page.html\" target=\"_blank\">Text</a></hTmL>')


### PR DESCRIPTION
## Description

This updates one of the test_html_rewriter doctests so it matches the output of the latest Python versions.

## Motivation and Context

In Python 3.9.24, 3.10.19, 3.11.14, 3.12.12, 3.13.6 and 3.14.0  HtmlParser was changed as a security update to more correctly follow the HTML5 standard. This changed the output of one of our tests. The output change doesn't appear to have a meaningful impact in this case as browsers treat it as a comment either way.

Fixes #969

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.

Still seeing some intermittent test failures but they're in `test_agg_select_mem_unrewrite_headers` which appears to be making requests to remote servers.