### PR TITLE
Add per collection-index `use_indexer_date_filter` option

### DIFF
--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -119,12 +119,12 @@ class FileIndexSource(BaseIndexSource):
 class RemoteIndexSource(BaseIndexSource):
     CDX_MATCH_RX = re.compile('^cdxj?\+(?P<url>https?\:.*)')
 
-    def __init__(self, api_url, replay_url, url_field='load_url', closest_limit=100, use_indexer_date_filter=False):
+    def __init__(self, api_url, replay_url, url_field='load_url', closest_limit=100, use_remote_date_filter=False):
         self.api_url = api_url
         self.replay_url = replay_url
         self.url_field = url_field
         self.closest_limit = closest_limit
-        self.use_indexer_date_filter = use_indexer_date_filter
+        self.use_remote_date_filter = use_remote_date_filter
         self._init_sesh()
 
     def _get_api_url(self, params):
@@ -135,7 +135,7 @@ class RemoteIndexSource(BaseIndexSource):
         if 'matchType' in params:
             api_url += '&matchType=' + params.get('matchType')
             
-        if self.use_indexer_date_filter:
+        if self.use_remote_date_filter:
             if 'from' in params:
                api_url += '&from=' + params.get('from')
             if 'to' in params:
@@ -218,9 +218,9 @@ class RemoteIndexSource(BaseIndexSource):
         if config['type'] != 'cdx':
             return
 
-        use_indexer_date_filter = config.get('use_indexer_date_filter', False)
+        use_remote_date_filter = config.get('use_remote_date_filter', False)
         
-        return cls(config['api_url'], config['replay_url'], use_indexer_date_filter=use_indexer_date_filter)
+        return cls(config['api_url'], config['replay_url'], use_remote_date_filter=use_remote_date_filter)
 
 
 # =============================================================================


### PR DESCRIPTION
## Description
Adds a new per collection-index configuration option `use_indexer_date_filter`.  
When enabled for a collection, pywb forwards `from` and `to` date parameters to the indexer, if present.  
This shifts date filtering to the indexer, reducing pywb CPU and memory usage, preventing OOM conditions, and lowering network traffic.

Unfortunately, I could not find an appropriate section in the documentation to add this parameter description.  

## Motivation and Context
This feature allows heavy date filtering to be offloaded to the indexer, which prevents pywb server overload and high memory usage for large collections.  

## Screenshots (if appropriate):

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
