### PR TITLE
CI build fix for python 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ setenv = PYWB_NO_VERIFY_SSL = 1
 passenv = *
 deps =
     setuptools
-    pkg_resources
     -rtest_requirements.txt
     -rrequirements.txt
     -rextra_requirements.txt


### PR DESCRIPTION
Add `setuptools` installation as its no longer installed by default in py3.12