### PR TITLE
Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: checkout

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -10,14 +10,12 @@ remove some of these steps.*
 Requirements
 ~~~~~~~~~~~~
 
-pywb has tested in python 2.6, 2.7. It runs best in python 2.7.3+
+pywb is tested on python 3.9-3.14.
 
 pywb tool suite provides several WSGI applications, which have been
 tested under *wsgiref*, *waitress*, and uWSGI.
 
 For best results, the *uWSGI* container is recommended.
-
-Support for Python 3 is planned but not yet implemented.
 
 Sample Data
 ~~~~~~~~~~~

--- a/pywb/warcserver/test/testutils.py
+++ b/pywb/warcserver/test/testutils.py
@@ -167,7 +167,12 @@ class HttpBinLiveTests(object):
         super(HttpBinLiveTests, cls).setup_class(*args, **kwargs)
 
         from httpbin import app as httpbin_app
-        httpbin_app.config.update(JSONIFY_PRETTYPRINT_REGULAR=True)
+
+        if hasattr(httpbin_app, 'json'): # Flask >= 2.2.0
+            httpbin_app.json.compact = False
+        else:
+            httpbin_app.config.update(JSONIFY_PRETTYPRINT_REGULAR=True)
+
         cls.httpbin_server = GeventServer(httpbin_app)
 
         httpbin_local = 'http://localhost:' + str(cls.httpbin_server.port) + '/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,10 @@ jinja2>=3.1.2
 surt>=0.3.1
 brotlipy
 pyyaml
-werkzeug==2.2.3; python_version<"3.9"
-werkzeug==3.1.7; python_version>="3.9"
+werkzeug==3.1.7
 webencodings
 legacy-cgi; python_version>="3.13"
-gevent==22.10.2; python_version<"3.8"
-gevent==23.9.0.post1; python_version>="3.8" and python_version<"3.12"
+gevent==23.9.0.post1; python_version<"3.12"
 gevent==25.9.1; python_version>="3.12"
 greenlet>=2.0.2,<3.0; python_version<"3.12"
 greenlet==3.3.2; python_version>="3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,15 @@ jinja2>=3.1.2
 surt>=0.3.1
 brotlipy
 pyyaml
-werkzeug==2.2.3
+werkzeug==2.2.3; python_version<"3.9"
+werkzeug==3.1.7; python_version>="3.9"
 webencodings
 legacy-cgi; python_version>="3.13"
 gevent==22.10.2; python_version<"3.8"
-gevent==23.9.0.post1; python_version>="3.8" and python_version<"3.13"
-gevent==24.10.1; python_version>="3.13"
+gevent==23.9.0.post1; python_version>="3.8" and python_version<"3.12"
+gevent==25.9.1; python_version>="3.12"
 greenlet>=2.0.2,<3.0; python_version<"3.12"
-greenlet==3.2.4; python_version>="3.12.0rc0"
+greenlet==3.3.2; python_version>="3.12"
 webassets==2.0
 portalocker
 wsgiprox>=1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six
+setuptools; python_version>="3.12"
 warcio>=1.7.5
 requests
 redis==2.10.6
@@ -8,8 +9,10 @@ brotlipy
 pyyaml
 werkzeug==2.2.3
 webencodings
+legacy-cgi; python_version>="3.13"
 gevent==22.10.2; python_version<"3.8"
-gevent==23.9.0.post1; python_version>="3.8"
+gevent==23.9.0.post1; python_version>="3.8" and python_version<"3.13"
+gevent==24.10.1; python_version>="3.13"
 greenlet>=2.0.2,<3.0; python_version<"3.12"
 greenlet==3.2.4; python_version>="3.12.0rc0"
 webassets==2.0

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             "babel-vue-extractor"
         ],
     },
-    python_requires='>=3.7,<3.14',
+    python_requires='>=3.7,<3.15',
     tests_require=load_requirements("test_requirements.txt"),
     cmdclass={'test': PyTest},
     test_suite='',
@@ -154,6 +154,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: WSGI',

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             "babel-vue-extractor"
         ],
     },
-    python_requires='>=3.7,<3.13',
+    python_requires='>=3.7,<3.14',
     tests_require=load_requirements("test_requirements.txt"),
     cmdclass={'test': PyTest},
     test_suite='',
@@ -153,6 +153,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: WSGI',

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             "babel-vue-extractor"
         ],
     },
-    python_requires='>=3.7,<3.15',
+    python_requires='>=3.9,<3.15',
     tests_require=load_requirements("test_requirements.txt"),
     cmdclass={'test': PyTest},
     test_suite='',
@@ -147,8 +147,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ testpaths =
     tests
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312
+envlist = py37, py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 setenv = PYWB_NO_VERIFY_SSL = 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ testpaths =
     tests
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, py313
+envlist = py37, py38, py39, py310, py311, py312, py313, py314
 
 [gh-actions]
 python =
@@ -13,6 +13,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 setenv = PYWB_NO_VERIFY_SSL = 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ testpaths =
     tests
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, py313, py314
+envlist = py39, py310, py311, py312, py313, py314
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Description

- update werkzeug, gevent, greenlet to latest version for 3.14 support but conditionally pin when necessary to not break older Python
- Flask 2.2.0 replaced JSONIFY_PRETTYPRINT_REGULAR with app.json.compact so support both
- setuptools is no longer included by default since Python 3.12 so add it
- cgi was removed in Python 3.13 so replace it with legacy-cgi
- add python 3.13 and 3.14 to test matrix in both tox and the Github action

## Motivation and Context

To allow pywb to run on Python 3.13 and 3.14.
Fixes #979

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
