### PR TITLE
Fix empty replayPrefix in client-side replay service worker registration

### DIFF
--- a/pywb/static/loadWabac.js
+++ b/pywb/static/loadWabac.js
@@ -11,7 +11,7 @@ class WabacReplay
     this.injectScripts = injectScripts;
     this.adblockUrl = undefined;
 
-    this.queryParams = {"replayPrefix": ""};
+    this.queryParams = {"replayPrefix": this.prefix};
     if (this.isRoot) {
       this.queryParams["root"] = "$root";
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description

Fix `loadWabac.js` to pass the actual replay prefix when registering the service worker for client-side replay.

Based on the surrounding code in `loadWabac.js`, it seems likely that this was the original intention.

## Motivation and Context

We experienced various strange issues involving pages not loading properly in client replay mode when serving via one or more reverse proxies (traefik + oauth2-proxy in our case). The issues do not appear when serving pywb directly from localhost.

While debugging, we found that WabacReplay was registering the service worker with an empty `replayPrefix` query parameter:
```
/static/sw.js?replayPrefix=
```

Providing the correct replay prefix to the service worker in `loadWabac.js` resolved the issue for us.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
