### PR TITLE
Properly escape JS values in head_insert template

### DIFF
--- a/pywb/rewrite/templateview.py
+++ b/pywb/rewrite/templateview.py
@@ -17,12 +17,6 @@ from importlib.resources import files
 import os
 import logging
 
-try:
-    import ujson as json
-except ImportError:  # pragma: no cover
-    import json
-
-
 # ============================================================================
 class RelEnvironment(Environment):
     """Override join_path() to enable relative template paths."""
@@ -257,16 +251,6 @@ class JinjaEnv(object):
             """
             split = urlsplit(url)
             return split
-
-        @self.template_filter()
-        def tojson(obj):
-            """Converts the supplied object/array/any to a JSON string if it can be JSONified
-
-            :param any obj: The value to be converted to a JSON string
-            :return: The JSON string representation of the supplied value
-            :rtype: str
-            """
-            return json.dumps(obj)
 
         @self.template_filter()
         def tobool(bool_val):

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -1,10 +1,8 @@
-{% autoescape false %}
-
 <!-- WB Insert -->
 <script>
 {% set urlsplit = cdx.url | urlsplit %}
   wbinfo = {};
-  wbinfo.top_url = "{{ top_url }}";
+  wbinfo.top_url = {{ top_url | tojson }};
 {% if is_framed %}
   // Fast Top-Frame Redirect
   if (window == window.top && wbinfo.top_url) {
@@ -16,16 +14,16 @@
     }
   }
 {% endif %}
-  wbinfo.url = "{{ cdx.url }}";
-  wbinfo.timestamp = "{{ cdx.timestamp }}";
-  wbinfo.request_ts = "{{ wb_url.timestamp }}";
-  wbinfo.prefix = decodeURI("{{ wb_prefix }}");
-  wbinfo.mod = "{{ replay_mod }}";
+  wbinfo.url = {{ cdx.url | tojson }};
+  wbinfo.timestamp = {{ cdx.timestamp | tojson }};
+  wbinfo.request_ts = {{ wb_url.timestamp | tojson }};
+  wbinfo.prefix = decodeURI({{ wb_prefix | tojson }});
+  wbinfo.mod = {{ replay_mod | tojson }};
   wbinfo.is_framed = {{ is_framed | tobool }};
   wbinfo.is_live = {{ is_live | tobool }};
-  wbinfo.coll = "{{ coll }}";
-  wbinfo.proxy_magic = "{{ env.pywb_proxy_magic }}";
-  wbinfo.static_prefix = "{{ static_prefix }}/";
+  wbinfo.coll = {{ coll | tojson }};
+  wbinfo.proxy_magic = {{ env.pywb_proxy_magic | default('') | tojson }};
+  wbinfo.static_prefix = {{ (static_prefix + "/") | tojson }};
   wbinfo.enable_auto_fetch = {{ config.enable_auto_fetch | tobool }};
   wbinfo.target_frame = "___wb_replay_top_frame";
 </script>
@@ -37,10 +35,10 @@
 {% if not wb_url.is_banner_only or (env.pywb_proxy_magic and (config.enable_auto_fetch or config.proxy.enable_wombat)) %}
 <script src='{{ static_prefix }}/{{ whichWombat }}'> </script>
 <script>
-  wbinfo.wombat_ts = "{{ wombat_ts }}";
-  wbinfo.wombat_sec = "{{ wombat_sec }}";
-  wbinfo.wombat_scheme = "{{ urlsplit.scheme }}";
-  wbinfo.wombat_host = "{{ urlsplit.netloc }}";
+  wbinfo.wombat_ts = {{ wombat_ts | tojson }};
+  wbinfo.wombat_sec = {{ wombat_sec | string | tojson }};
+  wbinfo.wombat_scheme = {{ urlsplit.scheme | tojson }};
+  wbinfo.wombat_host = {{ urlsplit.netloc | tojson }};
 
   wbinfo.wombat_opts = {};
 
@@ -68,11 +66,9 @@
 
 {% if not is_framed %}
 
-{{ custom_banner_html }}
+{{ custom_banner_html | safe }}
 
 {% endif %}
-
-{% endautoescape %}
 
 <!-- End WB Insert -->
 

--- a/tests/test_auto_colls.py
+++ b/tests/test_auto_colls.py
@@ -314,15 +314,13 @@ class TestManagedColls(CollsDirMixin, BaseConfigTest):
         assert resp.status_int == 200
         assert resp.content_type == 'text/html'
         assert 'overriden search page: ' in resp.text
-        #assert '"some":"value"' in resp.text, resp.text
-        assert '{&#34;some&#34;:&#34;value&#34;}' in resp.text, resp.text
+        assert '"some": "value"' in resp.text, resp.text
 
     def test_replay_banner_metadata(self):
         """Test adding metadata in custom banner for unframed replay."""
         resp = self.get('/test/20140103030321/http://example.com/?example=1', None)
         assert '<div>Custom Banner Here!</div>' in resp.text
-        #assert '"some":"value"' in resp.text
-        assert '{&#34;some&#34;:&#34;value&#34;}' in resp.text, resp.text
+        assert '"some": "value"' in resp.text, resp.text
 
     def test_more_custom_templates_replay(self, fmod):
         resp = self.get('/test/20140103030321{0}/http://example.com/?example=1', fmod)

--- a/tests/test_templateview.py
+++ b/tests/test_templateview.py
@@ -1,0 +1,50 @@
+from pywb.rewrite.templateview import JinjaEnv
+
+
+def render_head_insert(attack):
+    template = JinjaEnv().jinja_env.get_template('head_insert.html')
+
+    return template.render(
+        cdx={
+            'url': 'https://example.test/' + attack,
+            'timestamp': attack,
+        },
+        top_url=attack,
+        wb_url={
+            'timestamp': attack,
+            'is_banner_only': False,
+        },
+        wb_prefix=attack,
+        replay_mod=attack,
+        is_framed=False,
+        is_live=False,
+        coll=attack,
+        env={},
+        static_prefix='/static',
+        config={
+            'enable_auto_fetch': False,
+            'enable_flash_video_rewrite': False,
+            'transclusions_version': 0,
+        },
+        wombat_ts=attack,
+        wombat_sec=attack,
+        inject_scripts=[],
+        custom_banner_html='<div id="custom-banner"></div>',
+    )
+
+
+def test_head_insert_uses_html_safe_json():
+    attack = '</script><script>globalThis.pwned = true</script>'
+
+    rendered = render_head_insert(attack)
+
+    assert attack not in rendered
+    assert '\\u003c' in rendered
+    assert 'wbinfo.proxy_magic = "";' in rendered
+    assert rendered.count('<script>') == 2
+
+
+def test_head_insert_preserves_custom_banner_html():
+    rendered = render_head_insert('safe')
+
+    assert '<div id="custom-banner"></div>' in rendered


### PR DESCRIPTION
## Description

Removes the custom tojson filter in favor of the standard Jinja one which is actually safe in a HTML context (json.dumps doesn't escape `</script>`). This stops us using `ujson` but I wouldn't expect it's providing a worthwhile speedup for these small values anyway.

Removes the dangerous `autoescape false`. Instead uses the `tojson` filter for the JavaScript values and the `safe` filter for the trusted HTML of the custom banner.

## Motivation and Context

The lack of escaping is unsafe and is vulnerable to a malicious WARC file. See discussion in #990.

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
